### PR TITLE
chore(nightly): Improve logic to fetch meaningful commit message for release notes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -126,13 +126,24 @@ jobs:
     needs: [create-release, build-tauri]
 
     steps:
+      - name: Get meaningful commit message
+        id: get-commit-message
+        run: |
+          # 获取最后一次非合并提交消息
+          LAST_COMMIT_MESSAGE=$(git log --pretty=format:"%s" -n 1 --skip=0 | grep -v "^Merge pull request")
+          if [ -z "$LAST_COMMIT_MESSAGE" ]; then
+            # 如果最新的提交是合并消息，则获取前一条提交
+            LAST_COMMIT_MESSAGE=$(git log --pretty=format:"%s" -n 1 --skip=1)
+          fi
+          echo "LAST_COMMIT_MESSAGE=$LAST_COMMIT_MESSAGE" >> $GITHUB_ENV
+
       - name: publish release
         id: publish-release
         uses: actions/github-script@v7
         env:
           release_id: ${{ needs.create-release.outputs.release_id }}
           PACKAGE_VERSION: ${{ needs.create-release.outputs.package_version }}
-          LAST_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          LAST_COMMIT_MESSAGE: ${{ env.LAST_COMMIT_MESSAGE }}
         with:
           script: |
             github.rest.repos.updateRelease({


### PR DESCRIPTION
- Added a step to retrieve the last non-merge commit message.
- If the latest commit is a merge commit, it now falls back to the previous commit message.
- Updated the publish-release step to use the fetched commit message from the environment variable.

This change ensures that the release notes contain a relevant commit message even when the latest commit is a merge commit.