### PR TITLE
chore: Update tracing release log level to warn in Cargo.toml

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }
 time = { version = "0", features = ['macros', 'serde'] }
-tracing = { version = "0", features = ["log", "release_max_level_info"] }
+tracing = { version = "0", features = ["log", "release_max_level_warn"] }
 tracing-subscriber = { version = "0", features = [
   'time',
   'env-filter',


### PR DESCRIPTION
- Modify the 'tracing' crate features to set the maximum logging level to warnings in release builds.