### PR TITLE
chore(daemon, src-tauri): update dependencies and features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4765,17 +4765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4798,12 +4787,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "time",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-serde",
 ]
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -12,7 +12,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-windows = { version = "0", features = [
+windows = { version = "0", default-features = false, features = [
     "Devices_Geolocation",
     "Win32_System_Registry",
     "System_UserProfile",
@@ -20,19 +20,26 @@ windows = { version = "0", features = [
     "Win32_UI",
     "Win32_UI_WindowsAndMessaging",
 ] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
 serde_valid = "0"
-tokio = { version = "1", features = [
+tokio = { version = "1", default-features = false, features = [
     "macros",
     "time",
     "fs",
     "rt",
     "rt-multi-thread",
 ] }
-time = { version = "0", features = ['macros', 'serde'] }
-tracing = { version = "0", features = ["log", "release_max_level_warn"] }
-tracing-subscriber = { version = "0", features = [
+time = { version = "0", default-features = false, features = [
+    'macros',
+    'serde',
+] }
+tracing = { version = "0", default-features = false, features = [
+    "log",
+    "release_max_level_info",
+] }
+tracing-subscriber = { version = "0", default-features = false, features = [
+    "fmt",
     'time',
     "local-time",
     'env-filter',
@@ -42,6 +49,10 @@ thiserror = "2"
 toml = "0"
 dirs = "5"
 regex = "1"
+
+[features]
+default = []
+log-color = ["tracing-subscriber/ansi"]
 
 [profile.release]
 panic = "abort"

--- a/daemon/src/log.rs
+++ b/daemon/src/log.rs
@@ -51,7 +51,7 @@ pub fn setup_logging(pkg_name: &str) {
         .with_writer(writer);
 
     if cfg!(debug_assertions) {
-        builder.init();
+        builder.with_ansi(true).init();
     } else {
         builder.json().init();
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tauri build",
     "serve": "vite preview",
     "tauri": "tauri",
-    "start:dev": "cross-env RUST_BACKTRACE=1 tauri dev",
+    "start:dev": "cross-env RUST_BACKTRACE=1 tauri dev --features log-color",
     "check": "biome check --write src",
     "dev": "bun run start:dev"
   },

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,13 +21,19 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 dwall = { version = "0", path = "../daemon" }
 
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "process"] }
-tracing = { version = "0", features = ["log", "release_max_level_warn"] }
+tokio = { version = "1", default-features = false, features = [
+    "macros",
+    "process",
+] }
+tracing = { version = "0", default-features = false, features = [
+    "log",
+    "release_max_level_info",
+] }
 thiserror = "2"
 window-vibrancy = "0"
-windows = { version = "0", features = [
+windows = { version = "0", default-features = false, features = [
     "Win32_System_Registry",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_ProcessStatus",
@@ -39,6 +45,10 @@ zip-extract = "0"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
+
+[features]
+default = []
+log-color = ["dwall/log-color"]
 
 [profile.release]
 panic = "abort"


### PR DESCRIPTION
- Disable default features for `windows`, `serde`, `tokio`, `time`, `tracing` and `tracing-subscriber` to optimize build.
- Add `default-features = false` to ensure only explicitly specified features are enabled.
- Introduce new `log-color` feature in both `daemon` and `src-tauri` for colored logging.
- Update `setup_logging` function in `daemon/src/log.rs` to use ANSI color codes when debug assertions are enabled.
- Modify `start:dev` script in `package.json` to include `log-color` feature during development startup.

This commit aims to streamline dependency management and enhance the logging experience with color support.