### PR TITLE
feat(process_manager): Add debug mode handling for daemon process detection

### DIFF
--- a/src-tauri/src/process_manager.rs
+++ b/src-tauri/src/process_manager.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
+
 use windows::Win32::System::ProcessStatus::GetModuleFileNameExW;
 use windows::Win32::System::{
     Diagnostics::ToolHelp::{
@@ -85,12 +86,25 @@ pub fn find_daemon_process() -> DwallSettingsResult<Option<u32>> {
                             full_path_str
                         );
 
-                        if full_path_str.eq_ignore_ascii_case(daemon_path_str) {
-                            info!(
-                                "Found matching daemon process. PID: {}",
-                                process_entry.th32ProcessID
-                            );
-                            return Ok(Some(process_entry.th32ProcessID));
+                        if cfg!(debug_assertions) {
+                            use std::ffi::OsStr;
+                            use std::path::Path;
+                            let full_path = Path::new(full_path_str);
+                            if full_path.file_name() == Some(OsStr::new("dwall.exe")) {
+                                info!(
+                                    "Found matching daemon process. PID: {}",
+                                    process_entry.th32ProcessID
+                                );
+                                return Ok(Some(process_entry.th32ProcessID));
+                            }
+                        } else {
+                            if full_path_str.eq_ignore_ascii_case(daemon_path_str) {
+                                info!(
+                                    "Found matching daemon process. PID: {}",
+                                    process_entry.th32ProcessID
+                                );
+                                return Ok(Some(process_entry.th32ProcessID));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
In the `find_daemon_process` function, added conditional logic to handle daemon process detection differently when debug assertions are enabled. Specifically, in debug mode, the function now checks if the file name of the process is "dwall.exe" rather than comparing the full path with `daemon_path_str`.

This change allows for more flexible daemon process identification during development and debugging, without affecting the release build behavior.