### PR TITLE
refactor: Extract theme daemon spawning logic into a dedicated module

### DIFF
--- a/src-tauri/src/theme.rs
+++ b/src-tauri/src/theme.rs
@@ -1,0 +1,16 @@
+use std::{os::windows::process::CommandExt, process::Command};
+
+use windows::Win32::System::Threading::CREATE_NO_WINDOW;
+
+use crate::{error::DwallSettingsResult, DAEMON_EXE_PATH};
+
+pub fn spawn_apply_daemon() -> DwallSettingsResult<()> {
+    let daemon_path = DAEMON_EXE_PATH.get().unwrap().to_str().unwrap();
+
+    let handle = Command::new(daemon_path)
+        .creation_flags(CREATE_NO_WINDOW.0)
+        .spawn()?;
+    info!(pid = handle.id(), "Spawned daemon using subprocess");
+
+    Ok(())
+}


### PR DESCRIPTION
- Moved the logic for spawning the theme application daemon into a new file `theme.rs`.
- Removed unnecessary imports from `lib.rs` as they are now handled in `theme.rs`.
- Simplified the `apply_theme` function by calling the new `spawn_apply_daemon` function.
- Added a new module `mod theme;` to include the newly created `theme.rs` file.

This change improves code organization and separation of concerns, making the codebase easier to maintain and understand.