### PR TITLE
chore: Ensure timely build of daemon process during development

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tauri build",
     "serve": "vite preview",
     "tauri": "tauri",
-    "start:dev": "cross-env RUST_BACKTRACE=1 tauri dev --features log-color",
+    "start:dev": "cargo build -p dwall --features log-color && cross-env RUST_BACKTRACE=1 tauri dev --features log-color",
     "check": "biome check --write src",
     "dev": "bun run start:dev"
   },
@@ -17,7 +17,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-shell": "^2.0.1",
-    "alley-components": "^0.3.8",
+    "alley-components": "^0.3.10",
     "solid-icons": "^1.1.0",
     "solid-js": "^1.9.3",
     "solid-styled-components": "^0.28.5"
@@ -27,7 +27,7 @@
     "cross-env": "^7.0.3",
     "sass": "^1.81.0",
     "typescript": "^5.7.2",
-    "vite": "^6.0.1",
+    "vite": "^6.0.2",
     "vite-plugin-solid": "^2.11.0",
     "@tauri-apps/cli": "^2.1.0"
   }


### PR DESCRIPTION
- Modified `start:dev` script to build the `dwall` package with cargo before launching the dev server. This ensures the daemon process is up-to-date when starting the development environment.