### PR TITLE
fix(daemon): Prevent command prompt window from showing on daemon starup

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 #[tokio::main]
 async fn main() -> dwall::DwallResult<()> {
     dwall::setup_logging(&env!("CARGO_PKG_NAME").replace("-", "_"));


### PR DESCRIPTION
- Added the `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]` attribute to ensure that the daemon does not open a command prompt window when started on Windows outside of debug mode.