### PR TITLE
fix(App): Ensure onMenuItemClick is called when a valid theme is found

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ const App = () => {
       const themeIndex = themes.findIndex((t) => t.id === applied_theme_id);
       if (themeIndex !== -1) {
         setIndex(themeIndex);
+        onMenuItemClick(themeIndex);
         setAppliedThemeID(applied_theme_id);
         return;
       }


### PR DESCRIPTION
- Added call to onMenuItemClick with the themeIndex when a valid theme is identified.
- This change addresses an issue where the existence of the current theme was not properly checked.