### PR TITLE
chore: Fix template literal syntax in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,7 +149,7 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/v${process.env.PACKAGE_VERSION}',
+              ref: `refs/tags/v${process.env.PACKAGE_VERSION}`,
               sha: context.sha
             })
 


### PR DESCRIPTION
- Updated the syntax for creating a Git tag in the publish workflow to use proper template literal backticks.