### PR TITLE
chore: Update repository reference in nightly and publish workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: delete old nightly release
         if: steps.get-release.outputs.result != ''
-        run: gh release delete nightly --cleanup-tag -R dwall-assets
+        run: gh release delete nightly --cleanup-tag -R thep0y/dwall-assets
         env:
           GH_TOKEN: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -240,6 +240,6 @@ jobs:
 
       - name: delete old nightly tag
         if: env.RELEASE_ID != ''
-        run: gh release delete nightly --cleanup-tag -R dwall-assets
+        run: gh release delete nightly --cleanup-tag -R thep0y/dwall-assets
         env:
           GH_TOKEN: ${{ secrets.DWALL_ASSETS_GITHUB_TOKEN }}


### PR DESCRIPTION
- Modify the repository name from 'dwall-assets' to 'thep0y/dwall-assets' in the GitHub release deletion command for both nightly and publish workflows.