### PR TITLE
feat(download): generalize GitHub download URL path for themes

### DIFF
--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -25,7 +25,7 @@ async fn download_theme<'a>(
 
     // Construct GitHub download URL
     let github_url = format!(
-        "https://github.com/thep0y/dwall-assets/releases/download/v0.1.0/{}.zip",
+        "https://github.com/thep0y/dwall-assets/releases/download/themes/{}.zip",
         theme_id.replace(" ", ".")
     );
     debug!("Generated GitHub download URL: {}", github_url);


### PR DESCRIPTION
- Updated the download URL path to use a generic 'themes' directory instead of a version-specific one.
- This enhancement allows for more flexible and maintainable theme downloads from GitHub releases.