### PR TITLE
feat(wallpaper-manager): Add multi-monitor wallpaper management

### DIFF
--- a/daemon/src/theme/manager.rs
+++ b/daemon/src/theme/manager.rs
@@ -1,13 +1,13 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use windows::{
-    core::{Interface, HSTRING},
+    core::{Interface, HSTRING, PWSTR},
     Foundation::Uri,
     Storage::{IStorageFile, StorageFile},
     System::UserProfile::LockScreen,
-    Win32::UI::WindowsAndMessaging::{
-        SystemParametersInfoW, SPIF_SENDWININICHANGE, SPIF_UPDATEINIFILE, SPI_GETDESKWALLPAPER,
-        SPI_SETDESKWALLPAPER, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS,
+    Win32::{
+        System::Com::{CoCreateInstance, CLSCTX_ALL},
+        UI::Shell::{DesktopWallpaper, IDesktopWallpaper},
     },
 };
 
@@ -17,71 +17,218 @@ use crate::{error::DwallResult, solar::SolarAngle};
 pub struct WallpaperManager;
 
 impl WallpaperManager {
-    /// Retrieves the current desktop wallpaper path
-    fn get_current_desktop_wallpaper() -> DwallResult<PathBuf> {
-        let mut buffer = vec![0u16; 1024];
-
-        // TODO: `windows::Win32::UI::Shell::IDesktopWallpaper::GetWallpaper` may be better
+    /// Retrieves the number of monitors
+    fn get_monitor_count(desktop_wallpaper: &IDesktopWallpaper) -> DwallResult<u32> {
+        trace!("Attempting to retrieve monitor device path count");
         unsafe {
-            SystemParametersInfoW(
-                SPI_GETDESKWALLPAPER,
-                buffer.len() as u32,
-                Some(buffer.as_mut_ptr() as *mut _),
-                SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS(0),
-            )
-            .map_err(|e| {
-                error!("Failed to retrieve desktop wallpaper: {}", e);
-                e
-            })?;
-
-            let current_wallpaper = String::from_utf16_lossy(&buffer)
-                .trim_matches('\0')
-                .to_string();
-
-            debug!("Current desktop wallpaper path: {}", current_wallpaper);
-            Ok(PathBuf::from(current_wallpaper))
+            desktop_wallpaper.GetMonitorDevicePathCount().map_err(|e| {
+                error!(
+                    error = %e,
+                    "Critical failure: Unable to retrieve monitor device path count.
+                     This may indicate a system-level graphics configuration issue."
+                );
+                trace!("Monitor count retrieval failed with error: {}", e);
+                e.into()
+            })
         }
     }
 
-    /// Sets the desktop wallpaper
-    pub fn set_desktop_wallpaper(image_path: &Path) -> DwallResult<()> {
-        debug!(
-            "Target desktop wallpaper image path: {}",
-            image_path.display()
+    /// Checks if the wallpaper is already set for a specific monitor
+    fn is_wallpaper_already_set(
+        desktop_wallpaper: &IDesktopWallpaper,
+        monitor_path: PWSTR,
+        wallpaper_path: &HSTRING,
+    ) -> DwallResult<bool> {
+        trace!(
+            monitor_path = %unsafe{monitor_path.display()},
+            "Checking existing wallpaper for monitor"
         );
 
-        let current_wallpaper = Self::get_current_desktop_wallpaper()?;
-
-        if current_wallpaper == image_path {
-            info!("Desktop wallpaper already set: {}", image_path.display());
-            return Ok(());
-        }
-
-        let wide_path: Vec<u16> = image_path
-            .to_string_lossy()
-            .encode_utf16()
-            .chain(std::iter::once(0))
-            .collect();
-
-        // TODO: `windows::Win32::UI::Shell::IDesktopWallpaper::SetWallpaper` may be better
-        unsafe {
-            SystemParametersInfoW(
-                SPI_SETDESKWALLPAPER,
-                0,
-                Some(wide_path.as_ptr() as *mut _),
-                SPIF_UPDATEINIFILE | SPIF_SENDWININICHANGE,
-            )
-            .map_err(|e| {
+        let current_wallpaper_path = match unsafe { desktop_wallpaper.GetWallpaper(monitor_path) } {
+            Ok(path) => path,
+            Err(e) => {
                 error!(
-                    "Failed to set desktop wallpaper: {}, Error: {}",
-                    image_path.display(),
-                    e
+                    error = %e,
+                    monitor_path = %unsafe{monitor_path.display()},
+                    "Failed to retrieve current wallpaper for monitor"
                 );
-                e
-            })?;
+                return Err(e.into());
+            }
+        };
+
+        let is_same = *wallpaper_path == unsafe { current_wallpaper_path.to_hstring() }.unwrap();
+
+        trace!(
+            current_wallpaper_path = %unsafe{current_wallpaper_path.display()},
+            new_wallpaper_path = %wallpaper_path,
+            is_same = is_same,
+            "Wallpaper comparison result"
+        );
+
+        Ok(is_same)
+    }
+
+    /// Sets wallpaper for a specific monitor
+    fn set_monitor_wallpaper(
+        desktop_wallpaper: &IDesktopWallpaper,
+        monitor_path: PWSTR,
+        wallpaper_path: &HSTRING,
+        monitor_index: u32,
+    ) -> DwallResult<()> {
+        trace!(
+            monitor_index = monitor_index,
+            wallpaper_path = %wallpaper_path,
+            "Attempting to set wallpaper for specific monitor"
+        );
+
+        unsafe {
+            desktop_wallpaper
+                .SetWallpaper(monitor_path, wallpaper_path)
+                .map_err(|e| {
+                    error!(
+                        monitor_index = monitor_index,
+                        error = %e,
+                        wallpaper_path = %wallpaper_path,
+                        "Comprehensive wallpaper setting failure:
+                     Unable to apply wallpaper to specified monitor. 
+                     Check file permissions, path validity, and system graphics settings."
+                    );
+                    trace!(
+                        "Detailed wallpaper setting error for monitor {}: {}",
+                        monitor_index,
+                        e
+                    );
+                    e.into()
+                })
+        }
+    }
+
+    /// Sets the desktop wallpaper across all monitors
+    pub fn set_desktop_wallpaper(image_path: &Path) -> DwallResult<()> {
+        // Enhanced trace-level logging for initial wallpaper setting attempt
+        trace!(
+            image_path = %image_path.display(),
+            "Initiating desktop wallpaper configuration process"
+        );
+
+        // Validate image path before proceeding
+        if !image_path.exists() {
+            error!(
+                image_path = %image_path.display(),
+                "Image path does not exist. Cannot proceed with wallpaper setting."
+            );
+            return Err(
+                std::io::Error::new(std::io::ErrorKind::NotFound, "Image file not found").into(),
+            );
         }
 
-        info!("Desktop wallpaper updated: {}", image_path.display());
+        // Create desktop wallpaper instance with enhanced error handling
+        let desktop_wallpaper: IDesktopWallpaper = unsafe {
+            CoCreateInstance(&DesktopWallpaper as *const _, None, CLSCTX_ALL).map_err(|e| {
+                error!(
+                    error = %e,
+                    "Critical initialization failure:
+                     Unable to create desktop wallpaper COM instance. 
+                     This may indicate system COM registration issues."
+                );
+                trace!("Desktop wallpaper instance creation error: {}", e);
+                e
+            })?
+        };
+
+        // Get total number of monitors with context
+        let monitor_count = match Self::get_monitor_count(&desktop_wallpaper) {
+            Ok(count) => {
+                trace!(
+                    monitor_count = count,
+                    "Successfully retrieved monitor count"
+                );
+                count
+            }
+            Err(e) => {
+                error!(
+                    error = %e,
+                    "Wallpaper configuration aborted due to monitor count retrieval failure"
+                );
+                return Err(e);
+            }
+        };
+
+        // Convert image path to HSTRING with logging
+        let wallpaper_path = {
+            let path_str = image_path.to_string_lossy();
+            trace!(wallpaper_path = %path_str, "Converted image path to HSTRING");
+            HSTRING::from(path_str.as_ref())
+        };
+
+        // Iterate through monitors and set wallpaper with comprehensive logging
+        for i in 0..monitor_count {
+            let monitor_path = match unsafe { desktop_wallpaper.GetMonitorDevicePathAt(i) } {
+                Ok(path) => {
+                    trace!(
+                        monitor_index = i,
+                        monitor_path = %unsafe{path.display()},
+                        "Retrieved monitor device path"
+                    );
+                    path
+                }
+                Err(e) => {
+                    error!(
+                        monitor_index = i,
+                        error = %e,
+                        "Failed to retrieve monitor device path. Skipping this monitor."
+                    );
+                    continue;
+                }
+            };
+
+            // Skip if wallpaper is already set, with detailed logging
+            match Self::is_wallpaper_already_set(&desktop_wallpaper, monitor_path, &wallpaper_path)
+            {
+                Ok(true) => {
+                    info!(
+                        image_path = %image_path.display(),
+                        monitor_path = %unsafe{monitor_path.display()},
+                        monitor_index = i,
+                        "Wallpaper already set for this monitor. Skipping."
+                    );
+                    continue;
+                }
+                Ok(false) => {
+                    trace!(
+                        monitor_index = i,
+                        "Wallpaper needs to be updated for this monitor"
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        monitor_index = i,
+                        error = %e,
+                        "Error checking existing wallpaper. Attempting to set new wallpaper."
+                    );
+                }
+            }
+
+            // Set wallpaper for the monitor
+            if let Err(e) =
+                Self::set_monitor_wallpaper(&desktop_wallpaper, monitor_path, &wallpaper_path, i)
+            {
+                warn!(
+                    monitor_index = i,
+                    error = %e,
+                    "Failed to set wallpaper for a specific monitor. Continuing with other monitors."
+                );
+                // Continue to next monitor instead of completely failing
+                continue;
+            }
+        }
+
+        info!(
+            image_path = %image_path.display(),
+            monitor_count = monitor_count,
+            "Wallpaper configuration completed. Processed across all available monitors."
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
- Introduce functionality to retrieve the number of connected monitors.
- Implement checks for existing wallpapers on specific monitors before setting new ones.
- Enhance the method for setting desktop wallpapers to support multiple monitors.
- Improve error handling and logging throughout the WallpaperManager implementation.

This update significantly expands the capabilities of the WallpaperManager, providing more robust support for managing wallpapers across multiple monitors while ensuring better system compatibility and user experience through enhanced error reporting.