### PR TITLE
feat(daemon): Add Win32_UI_Shell and Win32_System_Com features

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -18,7 +18,9 @@ windows = { version = "0", default-features = false, features = [
     "System_UserProfile",
     "Storage",
     "Win32_UI",
+    "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_System_Com",
 ] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
This change updates the Cargo.toml configuration for the daemon to include the "Win32_UI_Shell" and "Win32_System_Com" features under the windows dependency. These additions enable access to additional Windows APIs for shell and COM operations.