### PR TITLE
feat(color_mode): Add deserialization and expose ColorMode enum

### DIFF
--- a/daemon/src/color_mode.rs
+++ b/daemon/src/color_mode.rs
@@ -1,3 +1,4 @@
+use serde::Deserialize;
 use windows::{
     core::PCWSTR,
     Win32::{
@@ -12,7 +13,8 @@ use windows::{
 
 use crate::error::{DwallResult, RegistryError};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
 pub enum ColorMode {
     Light,
     Dark,

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -10,6 +10,7 @@ mod theme;
 #[macro_use]
 extern crate tracing;
 
+pub use color_mode::{get_current_color_mode, ColorMode};
 pub use error::{DwallError, DwallResult};
 pub use lazy::APP_CONFIG_DIR;
 pub use log::setup_logging;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,8 +2,9 @@ use std::borrow::Cow;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use dwall::ColorMode;
 use dwall::{config::Config, setup_logging, ThemeValidator};
-use tauri::{AppHandle, Manager, RunEvent};
+use tauri::{AppHandle, Manager, RunEvent, WebviewWindow};
 use tokio::sync::OnceCell;
 
 use crate::auto_start::{check_auto_start, disable_auto_start, enable_auto_start};
@@ -145,6 +146,22 @@ async fn apply_theme(config: Config<'_>) -> DwallSettingsResult<()> {
     }
 }
 
+#[tauri::command]
+async fn set_titlebar_color_mode(
+    window: WebviewWindow,
+    color_mode: ColorMode,
+) -> DwallSettingsResult<()> {
+    let hwnd = window.hwnd()?;
+
+    let color = match color_mode {
+        ColorMode::Dark => 0x1F1F1F,
+        ColorMode::Light => 0xFAFAFA,
+    };
+
+    crate::window::set_titlebar_color(hwnd, color)?;
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() -> DwallSettingsResult<()> {
     setup_logging("dwall_settings_lib");
@@ -175,7 +192,8 @@ pub fn run() -> DwallSettingsResult<()> {
             disable_auto_start,
             enable_auto_start,
             download_theme_and_extract,
-            request_location_permission
+            request_location_permission,
+            set_titlebar_color_mode
         ]);
 
     if cfg!(debug_assertions) {


### PR DESCRIPTION
- daemon/src/color_mode.rs:
  - Added `serde::Deserialize` to the `ColorMode` enum.
  - Applied `#[serde(rename_all = "UPPERCASE")]` to ensure consistent serialization.

- daemon/src/lib.rs:
  - Exposed `ColorMode` and `get_current_color_mode` functions to the public API.

- src-tauri/src/lib.rs:
  - Imported `ColorMode` from the daemon library.
  - Added a new Tauri command `set_titlebar_color_mode` to set the titlebar color based on the `ColorMode` enum.

This commit enhances the `ColorMode` enum by adding deserialization support and exposes it to the Tauri application, allowing dynamic titlebar color changes based on the selected color mode.