### PR TITLE
fix(window): resolve DWMWA_CAPTION_COLOR compatibility issue on Windows 10

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,8 @@ windows = { version = "0", default-features = false, features = [
   "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_ProcessStatus",
   "Win32_Graphics_Dwm",
+  "Wdk_System_SystemServices",
+  "Win32_System_SystemInformation",
 ] }
 reqwest = "0"
 futures-util = "0"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@ use crate::postion::request_location_permission;
 use crate::process_manager::{find_daemon_process, kill_daemon};
 use crate::setup::setup_app;
 use crate::theme::spawn_apply_daemon;
-use crate::window::new_main_window;
+use crate::window::create_main_window;
 
 mod auto_start;
 mod download;
@@ -159,12 +159,7 @@ async fn set_titlebar_color_mode(
 ) -> DwallSettingsResult<()> {
     let hwnd = window.hwnd()?;
 
-    let color = match color_mode {
-        ColorMode::Dark => 0x1F1F1F,
-        ColorMode::Light => 0xFAFAFA,
-    };
-
-    crate::window::set_titlebar_color(hwnd, color)?;
+    crate::window::set_window_color_mode(hwnd, color_mode)?;
     Ok(())
 }
 
@@ -182,7 +177,7 @@ pub fn run() -> DwallSettingsResult<()> {
                     error!(error = %e, "Failed to set focus on existing window");
                 }
             } else {
-                match new_main_window(app) {
+                match create_main_window(app) {
                     Ok(_) => debug!("New main window created"),
                     Err(e) => error!(error = %e, "Failed to create new main window"),
                 }

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -4,7 +4,7 @@ use tauri::Manager;
 
 use crate::{
     auto_start::AutoStartManager, error::DwallSettingsError, process_manager::find_daemon_process,
-    read_config_file, theme::spawn_apply_daemon, window::new_main_window, DAEMON_EXE_PATH,
+    read_config_file, theme::spawn_apply_daemon, window::create_main_window, DAEMON_EXE_PATH,
 };
 
 pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
@@ -41,7 +41,7 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
     app.manage(auto_start_manager);
 
     info!("Creating main window");
-    new_main_window(app.app_handle())?;
+    create_main_window(app.app_handle())?;
 
     // If a theme is configured in the configuration file but the background process is not detected,
     // then run the background process when this program starts.

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -1,86 +1,191 @@
+use core::ffi;
 use std::error::Error;
 
+use dwall::ColorMode;
 use tauri::{WebviewUrl, WebviewWindowBuilder};
-use windows::Win32::{
-    Foundation::HWND,
-    Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_CAPTION_COLOR},
+use windows::{
+    Wdk::System::SystemServices::RtlGetVersion,
+    Win32::{
+        Foundation::{HWND, STATUS_SUCCESS},
+        Graphics::Dwm::{
+            DwmSetWindowAttribute, DWMWA_CAPTION_COLOR, DWMWA_USE_IMMERSIVE_DARK_MODE,
+        },
+        System::SystemInformation::OSVERSIONINFOW,
+    },
 };
 
 use crate::error::DwallSettingsResult;
 
-pub fn new_main_window(app: &tauri::AppHandle) -> Result<(), Box<dyn Error>> {
-    trace!("Entering new_main_window function");
+/// Creates the main application window with predefined settings
+///
+/// # Arguments
+/// * `app` - The Tauri application handle
+///
+/// # Returns
+/// A result indicating successful window creation or an error
+pub fn create_main_window(app: &tauri::AppHandle) -> Result<(), Box<dyn Error>> {
+    trace!("Initializing main application window");
 
-    trace!(
-        "Creating window with parameters: title='Dwall Settings', transparent=false, resizable=false, maximizable=false, visible=false, inner_size=(660, 600)"
+    // Define window configuration parameters
+    const WINDOW_TITLE: &str = "Dwall Settings";
+    const WINDOW_WIDTH: f64 = 660.0;
+    const WINDOW_HEIGHT: f64 = 600.0;
+
+    info!(
+        "Configuring window: title={}, dimensions={}x{}",
+        WINDOW_TITLE, WINDOW_WIDTH, WINDOW_HEIGHT
     );
-    let win_builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
-        .title("Dwall Settings")
+
+    let window_builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
+        .title(WINDOW_TITLE)
         .resizable(false)
         .maximizable(false)
         .visible(false)
-        .inner_size(660., 600.);
+        .inner_size(WINDOW_WIDTH, WINDOW_HEIGHT);
 
-    trace!("WebviewWindowBuilder configured");
-
-    let window = win_builder.build().map_err(|e| {
-        error!("Failed to build main window: {}", e);
-        e
-    })?;
-
-    trace!("Main window successfully built");
-
-    let raw_handle = window.hwnd().map_err(|e| {
-        error!("Failed to get window handle: {}", e);
-        e
-    })?;
-
-    trace!("Retrieved window handle: {:?}", raw_handle);
-
-    set_titlebar_color(raw_handle, 0xFAFAFA).map_err(|e| {
-        error!("Failed to set titlebar color: {}", e);
-        e
-    })?;
-
-    trace!("Exiting new_main_window function");
-    Ok(())
+    // Attempt to build the window
+    match window_builder.build() {
+        Ok(_) => {
+            info!("Main application window created successfully");
+            Ok(())
+        }
+        Err(build_error) => {
+            error!(
+                "Failed to create main window: {}. Detailed error: {:?}",
+                build_error, build_error
+            );
+            Err(build_error.into())
+        }
+    }
 }
 
-/// Set the titlebar color for a given window handle
+/// Sets the window's titlebar color mode based on the system version
 ///
 /// # Arguments
-/// * `hwnd` - The window handle to set the titlebar color for
-/// * `color` - The color to set, in BGR format (0xBBGGRR)
+/// * `window_handle` - The window handle
+/// * `color_mode` - The desired color mode (Dark or Light)
 ///
-/// # Notes
-/// - Color is in COLORREF format (0xBBGGRR)
-/// - Transparent colors cannot be set
-/// - Errors in setting the color are logged but do not halt execution
-pub fn set_titlebar_color(hwnd: HWND, color: u32) -> DwallSettingsResult<()> {
-    trace!("Entering set_titlebar_color function");
-    trace!(
-        "Setting titlebar color for HWND {:?} to 0x{:X}",
-        hwnd,
-        color
-    );
-    let result = unsafe {
-        DwmSetWindowAttribute(
-            hwnd,
-            DWMWA_CAPTION_COLOR,
-            &color as *const u32 as *const std::ffi::c_void,
-            std::mem::size_of::<u32>() as u32,
-        )
+/// # Returns
+/// A result indicating successful color mode change or an error
+pub fn set_window_color_mode(
+    window_handle: HWND,
+    color_mode: ColorMode,
+) -> DwallSettingsResult<()> {
+    trace!("Attempting to set window color mode: {:?}", color_mode);
+
+    // Determine color based on Windows version
+    let result = if is_windows_11_or_newer() {
+        set_windows_11_caption_color(window_handle, &color_mode)
+    } else {
+        set_legacy_dark_mode(window_handle, &color_mode)
     };
 
     match result {
         Ok(_) => {
-            trace!("Titlebar color set successfully");
+            info!("Window color mode set successfully to {:?}", color_mode);
             Ok(())
         }
-        Err(e) => {
-            error!("Failed to set titlebar color: {}", e);
-            trace!("Titlebar color setting error details: {:?}", e);
-            Err(e.into())
+        Err(error) => {
+            error!(
+                "Failed to set window color mode. Mode: {:?}, Error: {:?}",
+                color_mode, error
+            );
+            Err(error)
         }
     }
+}
+
+/// Sets caption color for Windows 11 and newer
+///
+/// # Arguments
+/// * `window_handle` - The window handle
+/// * `color_mode` - The desired color mode
+///
+/// # Returns
+/// A result of the color setting operation
+fn set_windows_11_caption_color(
+    window_handle: HWND,
+    color_mode: &ColorMode,
+) -> DwallSettingsResult<()> {
+    // Predefined color values for dark and light modes
+    const DARK_CAPTION_COLOR: u32 = 0x1F1F1F; // Dark gray
+    const LIGHT_CAPTION_COLOR: u32 = 0xFAFAFA; // Light gray
+
+    let caption_color = match color_mode {
+        ColorMode::Dark => DARK_CAPTION_COLOR,
+        ColorMode::Light => LIGHT_CAPTION_COLOR,
+    };
+
+    debug!(
+        "Setting Windows 11+ caption color. Mode: {:?}, Color: 0x{:X}",
+        color_mode, caption_color
+    );
+
+    unsafe {
+        DwmSetWindowAttribute(
+            window_handle,
+            DWMWA_CAPTION_COLOR,
+            &caption_color as *const u32 as *const std::ffi::c_void,
+            std::mem::size_of::<u32>() as u32,
+        )
+        .map_err(Into::into)
+    }
+}
+
+/// Sets dark mode for legacy Windows versions
+///
+/// # Arguments
+/// * `window_handle` - The window handle
+/// * `color_mode` - The desired color mode
+///
+/// # Returns
+/// A result of the dark mode setting operation
+fn set_legacy_dark_mode(window_handle: HWND, color_mode: &ColorMode) -> DwallSettingsResult<()> {
+    let dark_mode_value: u32 = match color_mode {
+        ColorMode::Dark => 1,
+        ColorMode::Light => 0,
+    };
+
+    debug!(
+        "Setting legacy dark mode. Mode: {:?}, Dark Mode Value: {}",
+        color_mode, dark_mode_value
+    );
+
+    unsafe {
+        DwmSetWindowAttribute(
+            window_handle,
+            DWMWA_USE_IMMERSIVE_DARK_MODE,
+            &dark_mode_value as *const _ as *const ffi::c_void,
+            std::mem::size_of::<u32>() as u32,
+        )
+        .map_err(Into::into)
+    }
+}
+
+/// Determines if the current Windows version is Windows 11 or newer
+///
+/// # Returns
+/// A boolean indicating whether the system is Windows 11 or newer
+fn is_windows_11_or_newer() -> bool {
+    let mut os_version_info = OSVERSIONINFOW {
+        dwOSVersionInfoSize: std::mem::size_of::<OSVERSIONINFOW>() as u32,
+        ..Default::default()
+    };
+
+    let version_check_status = unsafe { RtlGetVersion(&mut os_version_info) };
+
+    if version_check_status != STATUS_SUCCESS {
+        warn!(
+            "Failed to retrieve Windows version. Status code: {:?}",
+            version_check_status
+        );
+        return false;
+    }
+
+    debug!(
+        "Windows version detected. Build Number: {}",
+        os_version_info.dwBuildNumber
+    );
+
+    os_version_info.dwBuildNumber > 22000
 }


### PR DESCRIPTION
- Fixed a compatibility issue where `DwmSetWindowAttribute` with `DWMWA_CAPTION_COLOR` caused an error (0x80070057) on Windows 10, preventing the application from starting.
- Introduced `set_window_color_mode` to dynamically handle color mode settings based on the Windows version.
- Added `set_windows_11_caption_color` for Windows 11 and newer, using `DWMWA_CAPTION_COLOR`.
- Added `set_legacy_dark_mode` for legacy Windows versions (e.g., Windows 10), using `DWMWA_USE_IMMERSIVE_DARK_MODE`.
- Implemented `is_windows_11_or_newer` to detect the Windows version and apply the appropriate color mode setting.
- Updated `create_main_window` to use the new color mode setting logic.
- Added necessary Windows features (`Wdk_System_SystemServices` and `Win32_System_SystemInformation`) to `Cargo.toml` for version detection.