### PR TITLE
fix(ImageCarousel): handle index overflow when switching to fewer images

### DIFF
--- a/src/components/ImageCarousel/index.tsx
+++ b/src/components/ImageCarousel/index.tsx
@@ -20,6 +20,7 @@ export default function ImageCarousel(props: ImageCarouselProps) {
 
   const updateImageHeight = () => {
     const img = containerRef!.querySelector(".carousel-image");
+    setCurrentIndex(0);
     setImageHeight(img!.clientHeight);
   };
 


### PR DESCRIPTION
- Added `setCurrentIndex(0)` to reset the current index when the image height is updated.
- This resolves an issue where switching from a carousel with more images to one with fewer images would cause the component to fail displaying any image due to an index overflow.