### PR TITLE
feat(Settings): add lock screen wallpaper switch component

### DIFF
--- a/src/components/Settings/AutoStart.tsx
+++ b/src/components/Settings/AutoStart.tsx
@@ -2,7 +2,6 @@ import { LazySwitch } from "~/lazy";
 import SettingsItem from "./item";
 import { createSignal, onMount } from "solid-js";
 import { checkAutoStart, disableAutoStart, enableAutoStart } from "~/commands";
-import { AiOutlineCheck, AiOutlineClose } from "solid-icons/ai";
 
 const AutoStart = () => {
   const [autoStartState, setAutoStartState] = createSignal(false);

--- a/src/components/Settings/LockScreenWallpaperSwitch.tsx
+++ b/src/components/Settings/LockScreenWallpaperSwitch.tsx
@@ -1,0 +1,29 @@
+import { LazySwitch } from "~/lazy";
+import SettingsItem from "./item";
+import { useContext } from "solid-js";
+import { AppContext } from "~/context";
+import { writeConfigFile } from "~/commands";
+
+const LockScreenWallpaperSwitch = () => {
+  const { config, refetchConfig } = useContext(AppContext)!;
+
+  const onSwitchLockScreenWallpaper = async () => {
+    await writeConfigFile({
+      ...config()!,
+      lock_screen_wallpaper_enabled: !config()!.lock_screen_wallpaper_enabled,
+    });
+
+    refetchConfig();
+  };
+
+  return (
+    <SettingsItem label="同时设置锁屏壁纸">
+      <LazySwitch
+        checked={config()!.lock_screen_wallpaper_enabled}
+        onChange={onSwitchLockScreenWallpaper}
+      />
+    </SettingsItem>
+  );
+};
+
+export default LockScreenWallpaperSwitch;

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -17,6 +17,7 @@ import { ask, message } from "@tauri-apps/plugin-dialog";
 import UpdateDialog from "./UpdateDialog";
 import { useAppContext } from "~/context";
 import ThemesDirectory from "./ThemesDirectory";
+import LockScreenWallpaperSwitch from "./LockScreenWallpaperSwitch";
 
 const Settings = () => {
   const {
@@ -56,6 +57,8 @@ const Settings = () => {
           <AutoStart />
 
           <AutoDetectColorMode />
+
+          <LockScreenWallpaperSwitch />
 
           <CoordinateSource />
 

--- a/src/components/Settings/item.tsx
+++ b/src/components/Settings/item.tsx
@@ -1,5 +1,5 @@
 import { children, type JSXElement } from "solid-js";
-import { LazyCol, LazyFlex, LazyLabel } from "~/lazy";
+import { LazyFlex, LazyLabel } from "~/lazy";
 
 interface SettingsItemProps {
   label: string;

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -6,6 +6,7 @@ interface Config {
   themes_directory: string;
   coordinate_source: CoordinateSource;
   auto_detect_color_mode: boolean;
+  lock_screen_wallpaper_enabled: boolean;
 }
 
 interface CoordinateSourceAutomatic {


### PR DESCRIPTION
- Created new `LockScreenWallpaperSwitch` component in `src/components/Settings/LockScreenWallpaperSwitch.tsx`.
- Integrated the new component into the `Settings` component in `src/components/Settings/index.tsx`.
- Updated `types/config.d.ts` to include a new `lock_screen_wallpaper_enabled` boolean field in the `Config` interface.