### PR TITLE
refactor(ThemeShowcase): remove unsupported attributes from ImageCarousel

### DIFF
--- a/src/components/ThemeShowcase.tsx
+++ b/src/components/ThemeShowcase.tsx
@@ -31,8 +31,6 @@ const ThemeShowcase = (props: ThemeShowcaseProps) => {
           src,
           alt: props.currentTheme().id,
         }))}
-        height="auto"
-        width="480px"
       />
 
       <ThemeActions


### PR DESCRIPTION
- Removed `height="auto"` and `width="480px"` attributes as they do not exist in the props of ImageCarousel.