### PR TITLE
feat(download): add error handling for HTTP response status

### DIFF
--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -109,6 +109,11 @@ impl<'a> ThemeDownloader<'a> {
             err
         })?;
 
+        if let Err(e) = response.error_for_status_ref() {
+            error!("Got a error response: {}", e);
+            return Err(e.into());
+        }
+
         let total_size = response.content_length().unwrap_or(0);
         let mut stream = response.bytes_stream();
 


### PR DESCRIPTION
- Added error handling to check the HTTP response status using `error_for_status_ref`.
- Logs an error message and returns an error if the response status indicates a failure.