### PR TITLE
refactor: reset active menu item when settings button is clicked

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,8 +26,8 @@ const App = () => {
     appliedThemeID,
     downloadThemeID,
     setDownloadThemeID,
-    index,
-    setIndex,
+    menuItemIndex,
+    setMenuItemIndex,
     themeExists,
     currentTheme,
     onMenuItemClick,
@@ -45,13 +45,14 @@ const App = () => {
 
     await showWindow("main");
 
-    onMenuItemClick(index());
+    const mii = menuItemIndex();
+    if (mii !== undefined) onMenuItemClick(mii);
 
     const applied_theme_id = await getAppliedThemeID();
     if (applied_theme_id) {
       const themeIndex = themes.findIndex((t) => t.id === applied_theme_id);
       if (themeIndex !== -1) {
-        setIndex(themeIndex);
+        setMenuItemIndex(themeIndex);
         onMenuItemClick(themeIndex);
         setAppliedThemeID(applied_theme_id);
         return;
@@ -81,7 +82,7 @@ const App = () => {
         >
           <ThemeMenu
             themes={themes}
-            index={index()}
+            index={menuItemIndex()}
             appliedThemeID={appliedThemeID()}
             onMenuItemClick={(idx) => {
               setShowSettings(false);
@@ -96,7 +97,7 @@ const App = () => {
                 shape="circular"
                 icon={<AiFillSetting />}
                 onClick={() => {
-                  // setIndex(-1);
+                  setMenuItemIndex();
                   setShowSettings(true);
                 }}
               />
@@ -113,18 +114,18 @@ const App = () => {
           </div>
         </LazyFlex>
 
-        <Show when={!showSettings()} fallback={<Settings />}>
+        <Show when={!showSettings() && currentTheme()} fallback={<Settings />}>
           <ThemeShowcase
-            currentTheme={currentTheme}
+            currentTheme={currentTheme()!}
             themeExists={themeExists}
             appliedThemeID={appliedThemeID}
             downloadThemeID={downloadThemeID}
             setDownloadThemeID={setDownloadThemeID}
-            onDownload={() => setDownloadThemeID(currentTheme().id)}
+            onDownload={() => setDownloadThemeID(currentTheme()!.id)}
             onApply={onApply}
             onCloseTask={onCloseTask}
             onMenuItemClick={onMenuItemClick}
-            index={index}
+            index={menuItemIndex()!}
           />
         </Show>
       </LazyFlex>

--- a/src/components/Settings/GithubMirror.tsx
+++ b/src/components/Settings/GithubMirror.tsx
@@ -23,6 +23,7 @@ const GithubMirror = () => {
     <SettingsItem label="Github 镜像模板" vertical>
       <LazyInput
         style={{ flex: 15 }}
+        appearance="filled-lighter"
         value={value()}
         onChange={onChange}
         contentAfter={

--- a/src/components/Settings/ThemesDirectory.tsx
+++ b/src/components/Settings/ThemesDirectory.tsx
@@ -45,7 +45,7 @@ const ThemesDirectory = () => {
           </LazyButton>
         </LazyTooltip>
 
-        <LazyButton size="small" onClick={onChangePath}>
+        <LazyButton size="small" appearance="primary" onClick={onChangePath}>
           修改
         </LazyButton>
       </LazySpace>

--- a/src/components/Settings/UpdateDialog.tsx
+++ b/src/components/Settings/UpdateDialog.tsx
@@ -33,7 +33,7 @@ const UpdateDialog = (props: UpdateDialogProps) => {
   return (
     <LazyDialog
       show={!!props.update}
-      onClose={() => { }}
+      onClose={() => {}}
       maskClosable={false}
       size="large"
     >

--- a/src/components/ThemeContext.tsx
+++ b/src/components/ThemeContext.tsx
@@ -14,11 +14,15 @@ export const useThemeSelector = (themes: ThemeItem[]) => {
     createResource<Config>(readConfigFile);
   const [appliedThemeID, setAppliedThemeID] = createSignal<string>();
   const [downloadThemeID, setDownloadThemeID] = createSignal<string>();
-  const [index, setIndex] = createSignal(0);
+  const [menuItemIndex, setMenuItemIndex] = createSignal<number | undefined>(0);
   const [themeExists, setThemeExists] = createSignal(false);
   const [update, { refetch: recheckUpdate }] = createResource(() => check());
 
-  const currentTheme = createMemo(() => themes[index()]);
+  const currentTheme = createMemo(() => {
+    const idx = menuItemIndex();
+    if (idx === undefined) return;
+    return themes[idx];
+  });
 
   onMount(() => {
     window
@@ -33,7 +37,7 @@ export const useThemeSelector = (themes: ThemeItem[]) => {
   });
 
   const onMenuItemClick = async (idx: number) => {
-    setIndex(idx);
+    setMenuItemIndex(idx);
     try {
       await checkThemeExists(config()!.themes_directory, themes[idx].id);
       setThemeExists(true);
@@ -58,9 +62,12 @@ export const useThemeSelector = (themes: ThemeItem[]) => {
       return;
     }
 
+    const theme = currentTheme();
+    if (!theme) return;
+
     const newConfig = {
       ...config()!,
-      selected_theme_id: currentTheme().id,
+      selected_theme_id: theme.id,
     };
     await applyTheme(newConfig);
     refetchConfig();
@@ -74,8 +81,8 @@ export const useThemeSelector = (themes: ThemeItem[]) => {
     setAppliedThemeID,
     downloadThemeID,
     setDownloadThemeID,
-    index,
-    setIndex,
+    menuItemIndex,
+    setMenuItemIndex,
     themeExists,
     currentTheme,
     onMenuItemClick,

--- a/src/components/ThemeMenu.tsx
+++ b/src/components/ThemeMenu.tsx
@@ -3,7 +3,7 @@ import { LazyFlex, LazyTooltip } from "~/lazy";
 
 interface ThemeMenuProps {
   themes: ThemeItem[];
-  index: number;
+  index?: number;
   appliedThemeID?: string;
   onMenuItemClick: (idx: number) => void;
 }

--- a/src/components/ThemeShowcase.tsx
+++ b/src/components/ThemeShowcase.tsx
@@ -5,7 +5,7 @@ import { ThemeActions } from "./ThemeActions";
 import Download from "./Download";
 
 interface ThemeShowcaseProps {
-  currentTheme: () => ThemeItem;
+  currentTheme: ThemeItem;
   themeExists: () => boolean;
   appliedThemeID: () => string | undefined;
   downloadThemeID: () => string | undefined;
@@ -14,7 +14,7 @@ interface ThemeShowcaseProps {
   onApply: () => Promise<void>;
   onCloseTask: () => Promise<void>;
   onMenuItemClick: (index: number) => void;
-  index: () => number;
+  index: number;
 }
 
 const ThemeShowcase = (props: ThemeShowcaseProps) => {
@@ -27,17 +27,17 @@ const ThemeShowcase = (props: ThemeShowcaseProps) => {
       style={{ position: "relative" }}
     >
       <ImageCarousel
-        images={props.currentTheme().thumbnail.map((src) => ({
+        images={props.currentTheme.thumbnail.map((src) => ({
           src,
-          alt: props.currentTheme().id,
+          alt: props.currentTheme.id,
         }))}
       />
 
       <ThemeActions
         themeExists={props.themeExists()}
         appliedThemeID={props.appliedThemeID()}
-        currentThemeID={props.currentTheme().id}
-        onDownload={() => props.setDownloadThemeID(props.currentTheme().id)}
+        currentThemeID={props.currentTheme.id}
+        onDownload={() => props.setDownloadThemeID(props.currentTheme.id)}
         onApply={props.onApply}
         onCloseTask={props.onCloseTask}
         downloadThemeID={props.downloadThemeID()}
@@ -48,7 +48,7 @@ const ThemeShowcase = (props: ThemeShowcaseProps) => {
           themeID={props.downloadThemeID()!}
           onFinished={() => {
             props.setDownloadThemeID();
-            props.onMenuItemClick(props.index());
+            props.onMenuItemClick(props.index);
           }}
         />
       </Show>


### PR DESCRIPTION
- Renamed `index` and `setIndex` to `menuItemIndex` and `setMenuItemIndex` for better clarity.
- Updated `App` component to handle `menuItemIndex` correctly, ensuring the active menu item state is reset when the settings button is clicked.
- Modified `ThemeContext` to support optional `menuItemIndex` and improved logic for handling theme selection.
- Updated `ThemeMenu` and `ThemeShowcase` components to handle optional `index` prop and ensure type safety for `currentTheme`.