### PR TITLE
feat(style): Add dark mode styles for menu items

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -44,3 +44,14 @@
     }
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  .menu-item {
+    --menu-item-color-shadow: #61616185;
+
+    &.active,
+    &:hover {
+      background-color: #ffffff14;
+    }
+  }
+}


### PR DESCRIPTION
- Added media query for dark mode using `prefers-color-scheme: dark`.
- Defined `--menu-item-color-shadow` variable for dark mode.
- Updated background color for active and hover states of menu items in dark mode.