### PR TITLE
feat: Implement Image component for menu items in ThemeMenu

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -31,6 +31,7 @@
       height: 24px;
       background-color: var(--alley-color-success);
       clip-path: polygon(0 0, 100% 0, 0 100%);
+      z-index: 1;
     }
 
     &::after {
@@ -41,6 +42,7 @@
       left: 7px;
       color: white;
       font-size: 0.8rem;
+      z-index: 2;
     }
   }
 }

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,0 +1,74 @@
+import { children, createSignal, onCleanup } from "solid-js";
+import { LazySpinner } from "~/lazy";
+
+interface ImageProps {
+  ref?: HTMLImageElement;
+  src: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+  class?: string;
+  onLoad?: (naturalWidth: number, naturalHeight: number) => void;
+}
+
+const Image = (props: ImageProps) => {
+  const [loaded, setLoaded] = createSignal(false);
+
+  const handleLoad = () => {
+    const img = props.ref;
+    if (img) {
+      setLoaded(true);
+      props.onLoad?.(img.naturalWidth, img.naturalHeight);
+    }
+  };
+
+  const handleError = () => {
+    console.error("Image failed to load");
+  };
+
+  // Cleanup image element
+  onCleanup(() => { });
+
+  const resolved = children(() => (
+    <>
+      {!loaded() && (
+        <div
+          style={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+          }}
+        >
+          <LazySpinner />
+        </div>
+      )}
+      <img
+        ref={props.ref}
+        src={props.src}
+        alt={props.alt}
+        onLoad={handleLoad}
+        onError={handleError}
+        width={props.width}
+      />
+    </>
+  ));
+
+  return (
+    <div
+      class={props.class}
+      style={{
+        width: props.width ? `${props.width}px` : "auto",
+        height: props.height ? `${props.height}px` : "auto",
+        position: "relative",
+        display: "inline-flex",
+        "align-items": "center",
+        "justify-content": "center",
+      }}
+    >
+      {resolved()}
+    </div>
+  );
+};
+
+export default Image;

--- a/src/components/ThemeMenu.tsx
+++ b/src/components/ThemeMenu.tsx
@@ -1,18 +1,21 @@
 import { children } from "solid-js";
 import { LazyFlex, LazyTooltip } from "~/lazy";
+import Image from "./Image";
 
 interface ThemeMenuProps {
   themes: ThemeItem[];
   index?: number;
   appliedThemeID?: string;
-  onMenuItemClick: (idx: number) => void;
+  onMenuItemClick: (idx: number, height: number) => void;
 }
 
 export const ThemeMenu = (props: ThemeMenuProps) => {
+  const heights: Record<string, number> = {};
+
   const menu = children(() =>
     props.themes.map((item, idx) => (
       <div
-        onClick={() => props.onMenuItemClick(idx)}
+        onClick={() => props.onMenuItemClick(idx, heights[item.id])}
         classList={{
           "menu-item": true,
           active: idx === props.index,
@@ -29,7 +32,14 @@ export const ThemeMenu = (props: ThemeMenuProps) => {
           delay={500}
           showArrow
         >
-          <img src={item.thumbnail[0]} alt={item.id} width={64} />
+          <Image
+            src={item.thumbnail[0]}
+            width={64}
+            height={64}
+            onLoad={(height) => {
+              heights[item.id] = height;
+            }}
+          />
         </LazyTooltip>
       </div>
     )),

--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -88,3 +88,7 @@ export const LazySlider = lazy(
 export const LazyBadge = lazy(
   () => import("fluent-solid/lib/components/badge/badge"),
 );
+
+export const LazySpinner = lazy(
+  () => import("fluent-solid/lib/components/spinner"),
+);


### PR DESCRIPTION
- Created a new `Image` component in `src/components/Image.tsx` to handle image loading with a loading spinner.
- Integrated the `Image` component into `ThemeMenu.tsx` to display theme thumbnails with loading states.
- Updated `ThemeMenu.tsx` to pass image height to `onMenuItemClick` for better menu item handling.
- Imported and exported `LazySpinner` from `fluent-solid` in `src/lazy.ts` for use in the `Image` component.