### PR TITLE
refactor: replace `alley-components` tooltip with `fluent-solid`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tauri-apps/plugin-process": "~2.0.0",
     "@tauri-apps/plugin-updater": "^2.3.0",
     "alley-components": "^0.3.11",
-    "fluent-solid": "^0.1.9",
+    "fluent-solid": "^0.1.12",
     "solid-icons": "^1.1.0",
     "solid-js": "^1.9.3"
   },

--- a/src/App.scss
+++ b/src/App.scss
@@ -29,7 +29,7 @@
       left: 4px;
       width: 24px;
       height: 24px;
-      background-color: var(--alley-color-success);
+      background-color: var(--colorStatusSuccessBackground3);
       clip-path: polygon(0 0, 100% 0, 0 100%);
       z-index: 1;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { createSignal, onMount, Show } from "solid-js";
 import { LazyFlex, LazyTooltip, LazyButton, LazyBadge } from "~/lazy";
 import { AiFillSetting } from "solid-icons/ai";
-import { useDark } from "alley-components";
+import useDark from "alley-components/lib/hooks/useDark";
 
 import { ThemeMenu } from "./components/ThemeMenu";
 import Settings from "./components/Settings";
@@ -91,7 +91,11 @@ const App = () => {
           />
 
           <div style={{ position: "relative" }}>
-            <LazyTooltip placement="right" text="设置" delay={500} showArrow>
+            <LazyTooltip
+              positioning="after"
+              content="设置"
+              relationship="label"
+            >
               <LazyButton
                 appearance="transparent"
                 shape="circular"
@@ -103,7 +107,7 @@ const App = () => {
               />
             </LazyTooltip>
             <Show when={update()}>
-              <LazyTooltip text="检测到新版本" delay={250} showArrow>
+              <LazyTooltip content="检测到新版本" relationship="label">
                 <LazyBadge
                   style={{ position: "absolute", right: "4px", top: "4px" }}
                   size="extra-small"

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -27,7 +27,7 @@ const Image = (props: ImageProps) => {
   };
 
   // Cleanup image element
-  onCleanup(() => { });
+  onCleanup(() => {});
 
   const resolved = children(() => (
     <>

--- a/src/components/Settings/CoordinateSource.tsx
+++ b/src/components/Settings/CoordinateSource.tsx
@@ -1,10 +1,9 @@
-import { LazyButton, LazySpace, LazySwitch } from "~/lazy";
+import { LazyButton, LazyInputNumber, LazySpace, LazySwitch } from "~/lazy";
 import SettingsItem from "./item";
 import { AiOutlineCheck } from "solid-icons/ai";
 import { useAppContext } from "~/context";
 import { writeConfigFile } from "~/commands";
 import { createMemo, createSignal, Show } from "solid-js";
-import { InputNumber } from "alley-components";
 
 interface CoordinateInputProps {
   min: number;
@@ -23,7 +22,7 @@ const CoordinateInput = (props: CoordinateInputProps) => {
   };
 
   return (
-    <InputNumber
+    <LazyInputNumber
       placeholder={props.placeholder}
       min={props.min}
       max={props.max}
@@ -47,11 +46,11 @@ const CoordinateSource = () => {
     config()?.coordinate_source.type === "AUTOMATIC"
       ? {}
       : {
-        latitude: (config()?.coordinate_source as CoordinateSourceManual)
-          .latitude,
-        longitude: (config()?.coordinate_source as CoordinateSourceManual)
-          .longitude,
-      },
+          latitude: (config()?.coordinate_source as CoordinateSourceManual)
+            .latitude,
+          longitude: (config()?.coordinate_source as CoordinateSourceManual)
+            .longitude,
+        },
   );
 
   const onSwitchCoordinateSource = async () => {

--- a/src/components/Settings/ThemesDirectory.tsx
+++ b/src/components/Settings/ThemesDirectory.tsx
@@ -35,7 +35,7 @@ const ThemesDirectory = () => {
   return (
     <SettingsItem label="主题目录" vertical>
       <LazySpace gap={8} justify="between">
-        <LazyTooltip text="单击可打开主题目录" placement="top" delay={1000}>
+        <LazyTooltip content="单击可打开主题目录" relationship="label">
           <LazyButton
             appearance="transparent"
             style={{ padding: 0 }}

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -73,7 +73,7 @@ const Settings = () => {
           <LazySpace gap={8}>
             <LazyLabel>版本号</LazyLabel>
 
-            <LazyTooltip text="单击检测更新" placement="top">
+            <LazyTooltip content="单击检测更新" relationship="label">
               <LazyButton
                 appearance="transparent"
                 style={{ "min-width": "48px" }}

--- a/src/components/ThemeMenu.tsx
+++ b/src/components/ThemeMenu.tsx
@@ -23,14 +23,13 @@ export const ThemeMenu = (props: ThemeMenuProps) => {
         }}
       >
         <LazyTooltip
-          placement="right"
-          text={
+          positioning="after"
+          content={
             props.appliedThemeID === item.id
               ? `${item.id}（正在使用）`
               : item.id
           }
-          delay={500}
-          showArrow
+          relationship="label"
         >
           <Image
             src={item.thumbnail[0]}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,5 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
-import "alley-components/lib/index.css";
 import "fluent-solid/lib/index.css";
 import "./index.scss";
 import App from "./App";

--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -4,55 +4,12 @@ export const LazyFlex = lazy(
   () => import("alley-components/lib/components/flex"),
 );
 
-export const LazyTextArea = lazy(
-  () => import("alley-components/lib/components/input/text-area"),
-);
-
-export const LazyCol = lazy(
-  () => import("alley-components/lib/components/col"),
-);
-
-export const LazyRow = lazy(
-  () => import("alley-components/lib/components/row"),
-);
-
-export const LazyDivider = lazy(
-  () => import("alley-components/lib/components/divider"),
-);
-
 export const LazySpace = lazy(
   () => import("alley-components/lib/components/space"),
-);
-export const LazySpaceCompact = lazy(
-  () => import("alley-components/lib/components/space/compact"),
-);
-
-export const LazyTooltip = lazy(
-  () => import("alley-components/lib/components/tooltip"),
-);
-
-export const LazyTypography = lazy(
-  () => import("alley-components/lib/components/typography"),
-);
-
-export const LazyText = lazy(
-  () => import("alley-components/lib/components/typography/text"),
-);
-
-export const LazyTag = lazy(
-  () => import("alley-components/lib/components/tag"),
 );
 
 export const LazyDialog = lazy(
   () => import("alley-components/lib/components/dialog"),
-);
-
-export const LazyToast = lazy(
-  () => import("alley-components/lib/components/toast"),
-);
-
-export const LazyAlert = lazy(
-  () => import("alley-components/lib/components/alert"),
 );
 
 export const LazyInputNumber = lazy(
@@ -91,4 +48,8 @@ export const LazyBadge = lazy(
 
 export const LazySpinner = lazy(
   () => import("fluent-solid/lib/components/spinner"),
+);
+
+export const LazyTooltip = lazy(
+  () => import("fluent-solid/lib/components/tooltip"),
 );


### PR DESCRIPTION
- Replaced `alley-components` tooltip with `fluent-solid` tooltip in multiple files.
- Removed unused component imports from `lazy.ts`.
- Removed `alley-components/lib/index.css` import in `index.tsx`.
- Updated tooltip usage to match the new `fluent-solid` API.