### PR TITLE
feat(Dialog): Add new Dialog component and update UpdateDialog usage

### DIFF
--- a/src/components/Dialog/index.scss
+++ b/src/components/Dialog/index.scss
@@ -1,0 +1,85 @@
+.fluent-dialog {
+  &-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+  &-mask {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+    z-index: 1000;
+  }
+
+  & {
+    color: var(--colorNeutralForeground1);
+    background-color: var(--colorNeutralBackground1);
+    position: relative;
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    min-width: 320px;
+    max-width: 520px;
+    padding: 0;
+    z-index: 1001;
+
+    animation: dialogIn 0.2s ease-out;
+  }
+
+  &-header {
+    padding: 16px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    user-select: none;
+  }
+
+  &-title {
+    margin: 0;
+    font-size: 16px;
+    line-height: 22px;
+    font-weight: 600;
+  }
+
+  &-close {
+    padding: 0;
+    background: transparent;
+    border: none;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    transition: color 0.2s;
+  }
+
+  &-content {
+    padding: 24px;
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  &-footer {
+    padding: 16px 24px;
+    border-top: 1px solid #f0f0f0;
+    text-align: right;
+  }
+}
+
+@keyframes dialogIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -1,0 +1,99 @@
+import {
+  createSignal,
+  Show,
+  splitProps,
+  type Component,
+  type JSX,
+} from "solid-js";
+import "./index.scss";
+import { LazyButton, LazyDivider } from "~/lazy";
+
+interface DialogProps {
+  open?: boolean;
+  style?: JSX.CSSProperties;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  title?: string;
+  showMask?: boolean;
+  showCloseButton?: boolean;
+  maskClosable?: boolean;
+  footer?: JSX.Element;
+  children?: JSX.Element;
+  onClose?: () => void;
+}
+
+const Dialog: Component<DialogProps> = (props) => {
+  const [local, others] = splitProps(props, [
+    "open",
+    "defaultOpen",
+    "onOpenChange",
+    "title",
+    "onClose",
+    "showMask",
+    "showCloseButton",
+    "maskClosable",
+    "footer",
+    "children",
+  ]);
+
+  const [internalOpen, setInternalOpen] = createSignal(
+    local.defaultOpen || false,
+  );
+
+  const isControlled = () => local.open !== undefined;
+
+  const isOpen = () => (isControlled() ? local.open : internalOpen());
+
+  const handleClose = () => {
+    if (isControlled()) {
+      local.onOpenChange?.(false);
+    } else {
+      setInternalOpen(false);
+    }
+    local.onClose?.();
+  };
+
+  const handleMaskClick = () => {
+    if (local.maskClosable !== false) {
+      handleClose();
+    }
+  };
+
+  return (
+    <Show when={isOpen()}>
+      <div class="fluent-dialog-container">
+        <Show when={local.showMask !== false}>
+          <div class="fluent-dialog-mask" onClick={handleMaskClick} />
+        </Show>
+
+        <div class="fluent-dialog" {...others}>
+          <Show when={local.title}>
+            <div class="fluent-dialog-header">
+              <h3 class="fluent-dialog-title">{local.title}</h3>
+              <Show when={local.showCloseButton}>
+                <LazyButton
+                  class="fluent-dialog-close"
+                  onClick={handleClose}
+                  appearance="transparent"
+                  shape="circular"
+                  size="small"
+                >
+                  ×
+                </LazyButton>
+              </Show>
+            </div>
+            <LazyDivider />
+          </Show>
+
+          <div class="fluent-dialog-content">{local.children}</div>
+
+          <Show when={local.footer}>
+            <div class="fluent-dialog-footer">{local.footer}</div>
+          </Show>
+        </div>
+      </div>
+    </Show>
+  );
+};
+
+export default Dialog;

--- a/src/components/Settings/UpdateDialog.tsx
+++ b/src/components/Settings/UpdateDialog.tsx
@@ -2,7 +2,8 @@ import { relaunch } from "@tauri-apps/plugin-process";
 import type { Update } from "@tauri-apps/plugin-updater";
 import { createSignal, onMount } from "solid-js";
 import { killDaemon } from "~/commands";
-import { LazyDialog, LazyProgress } from "~/lazy";
+import { LazyProgress } from "~/lazy";
+import Dialog from "../Dialog";
 
 interface UpdateDialogProps {
   update: Update;
@@ -31,19 +32,14 @@ const UpdateDialog = (props: UpdateDialogProps) => {
   });
 
   return (
-    <LazyDialog
-      show={!!props.update}
-      onClose={() => {}}
-      maskClosable={false}
-      size="large"
-    >
+    <Dialog open={!!props.update} maskClosable={false} title="正在下载更新...">
       <LazyProgress
-        style={{ width: "540px" }}
+        style={{ width: "480px" }}
         thickness="large"
         max={total()}
         value={downloaded()}
       />
-    </LazyDialog>
+    </Dialog>
   );
 };
 

--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -8,10 +8,6 @@ export const LazySpace = lazy(
   () => import("alley-components/lib/components/space"),
 );
 
-export const LazyDialog = lazy(
-  () => import("alley-components/lib/components/dialog"),
-);
-
 export const LazyInputNumber = lazy(
   () => import("alley-components/lib/components/input-number"),
 );
@@ -52,4 +48,8 @@ export const LazySpinner = lazy(
 
 export const LazyTooltip = lazy(
   () => import("fluent-solid/lib/components/tooltip"),
+);
+
+export const LazyDivider = lazy(
+  () => import("fluent-solid/lib/components/divider"),
 );


### PR DESCRIPTION
- Added: New `Dialog` component with associated SCSS styles.
- Updated: `UpdateDialog` component to use the new `Dialog` component instead of the deprecated `LazyDialog`.
- Removed: Deprecated `LazyDialog` import from `src/lazy.ts`.
- Added: `LazyDivider` import to `src/lazy.ts` for use in the new `Dialog` component.