### PR TITLE
refactor(color_mode): Rename and simplify error enum

### DIFF
--- a/daemon/src/color_mode.rs
+++ b/daemon/src/color_mode.rs
@@ -17,18 +17,18 @@ use crate::error::DwallResult;
 
 /// Custom error types for registry operations
 #[derive(thiserror::Error, Debug)]
-pub enum ColorModeError {
+pub enum ColorModeRegistryError {
     #[error("Registry operation failed: Open key {0}")]
-    RegistryOpenFailed(u32),
+    Open(u32),
 
     #[error("Registry operation failed: Query value {0}")]
-    RegistryQueryFailed(u32),
+    Query(u32),
 
     #[error("Registry operation failed: Set value {0}")]
-    RegistrySetFailed(u32),
+    Set(u32),
 
     #[error("Registry operation failed: Close key {0}")]
-    RegistryCloseFailed(u32),
+    Close(u32),
 }
 
 #[derive(Debug, PartialEq, Deserialize)]
@@ -73,7 +73,7 @@ impl RegistryHelper {
                 }
                 err => {
                     error!("Failed to open registry key: {} (Error: {})", path, err.0);
-                    Err(ColorModeError::RegistryOpenFailed(err.0).into())
+                    Err(ColorModeRegistryError::Open(err.0).into())
                 }
             }
         }
@@ -90,7 +90,7 @@ impl RegistryHelper {
                 }
                 err => {
                     warn!("Failed to close registry key (Error: {})", err.0);
-                    Err(ColorModeError::RegistryCloseFailed(err.0).into())
+                    Err(ColorModeRegistryError::Close(err.0).into())
                 }
             }
         }
@@ -140,7 +140,7 @@ impl ColorModeManager {
                 }
                 err => {
                     error!("Failed to query color mode value (Error: {})", err.0);
-                    Err(ColorModeError::RegistryQueryFailed(err.0).into())
+                    Err(ColorModeRegistryError::Query(err.0).into())
                 }
             }
         }
@@ -187,7 +187,7 @@ impl ColorModeManager {
                         "Failed to set color mode (Apps result: {}, System result: {})",
                         set_apps_result.0, set_system_result.0
                     );
-                    return Err(ColorModeError::RegistrySetFailed(
+                    return Err(ColorModeRegistryError::Set(
                         set_apps_result.0 | set_system_result.0,
                     )
                     .into());

--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -1,6 +1,6 @@
 use windows::Win32::Foundation::WIN32_ERROR;
 
-use crate::color_mode::ColorModeError;
+use crate::color_mode::ColorModeRegistryError;
 
 pub type DwallResult<T> = std::result::Result<T, DwallError>;
 
@@ -17,7 +17,7 @@ pub enum DwallError {
     #[error(transparent)]
     Config(#[from] crate::config::ConfigError),
     #[error(transparent)]
-    ColorMode(#[from] ColorModeError),
+    ColorMode(#[from] ColorModeRegistryError),
     #[error(transparent)]
     NulError(#[from] std::ffi::NulError),
     #[error(transparent)]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,7 +46,7 @@ zip-extract = "0"
 open = "5"
 dirs = "5"
 
-[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2"


### PR DESCRIPTION
- Renamed `ColorModeError` to `ColorModeRegistryError` for better clarity.
- Simplified error variants by removing redundant "Registry operation failed" prefix.
- Updated all references to the renamed error enum and its variants.