### PR TITLE
fix: Adjust text color in Interval component for dark mode visibility

### DIFF
--- a/src/components/Settings/Interval.tsx
+++ b/src/components/Settings/Interval.tsx
@@ -17,7 +17,7 @@ const Interval = () => {
 
   return (
     <SettingsItem label="检测间隔">
-      <LazySpace gap={8}>
+      <LazySpace gap={8} style={{ color: "var(--colorNeutralForeground1)" }}>
         <LazySlider
           min={15}
           max={300}


### PR DESCRIPTION
- Fixed an issue where the text color in the Interval component remained black, making it difficult to read in dark mode.
- Updated the `LazySpace` component to use `style={{ color: "var(--colorNeutralForeground1)" }}` for better contrast in dark mode.