### PR TITLE
feat(i18n): Add internationalization support and initial translations

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ windows = { version = "0", default-features = false, features = [
   "Win32_Graphics_Dwm",
   "Wdk_System_SystemServices",
   "Win32_System_SystemInformation",
+  "Win32_Globalization"
 ] }
 reqwest = "0"
 futures-util = "0"

--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -1,0 +1,42 @@
+// ---------------- buttons ----------------
+pub(super) const BUTTON_APPLY: &str = "button-apply";
+pub(super) const BUTTON_DOWNLOAD: &str = "button-download";
+pub(super) const BUTTON_OPEN_LOG_DIRECTORY: &str = "button-open-log-directory";
+pub(super) const BUTTON_SELECT_FOLDER: &str = "button-select-folder";
+pub(super) const BUTTON_STOP: &str = "button-stop";
+
+// ---------------- labels ----------------
+pub(super) const LABEL_AUTOMATICALLY_RETRIEVE_COORDINATES: &str =
+    "label-automatically-retrieve-coordinates";
+pub(super) const LABEL_AUTOMATICALLY_SWITCH_TO_DARK_MODE: &str =
+    "label-automatically-switch-to-dark-mode";
+pub(super) const LABEL_CHECK_INTERVAL: &str = "label-check-interval";
+pub(super) const LABEL_GITHUB_MIRROR_TEMPLATE: &str = "label-github-mirror-template";
+pub(super) const LABEL_LAUNCH_AT_STARTUP: &str = "label-launch-at-startup";
+pub(super) const LABEL_SET_LOCK_SCREEN_WALLPAPER_SIMULTANEOUSLY: &str =
+    "label-set-lock-screen-wallpaper-simultaneously";
+pub(super) const LABEL_THEMES_DIRECTORY: &str = "label-themes-directory";
+pub(super) const LABEL_VERSION: &str = "label-version";
+
+// ---------------- tooltips ----------------
+pub(super) const TOOLTIP_CHECK_NEW_VERSION: &str = "tooltip-check-new-version";
+pub(super) const TOOLTIP_NEW_VERSION_AVAILABLE: &str = "tooltip-new-version-available";
+pub(super) const TOOLTIP_OPEN_THEMES_DIRECTORY: &str = "tooltip-open-themes-directory";
+pub(super) const TOOLTIP_SETTINGS: &str = "tooltip-settings";
+
+// ---------------- messages ----------------
+pub(super) const MESSAGE_CHANGE_THEMES_DIRECTORY: &str = "message-change-themes-directory";
+pub(super) const MESSAGE_DISABLE_STARTUP_FAILED: &str = "message-disable-startup-failed";
+pub(super) const MESSAGE_DOWNLOAD_FAILED: &str = "message-download-faild";
+pub(super) const MESSAGE_STARTUP_FAILED: &str = "message-startup-failed";
+pub(super) const MESSAGE_THEMES_DIRECTORY_MOVED: &str = "message-themes-directory-moved";
+pub(super) const MESSAGE_VERSION_IS_THE_LATEST: &str = "message-version-is-the-latest";
+
+// ---------------- units ----------------
+pub(super) const UNIT_SECOND: &str = "unit-second";
+
+// ---------------- titles ----------------
+pub(super) const TITLE_DOWNLOAD_FAILD: &str = "title-download-faild";
+pub(super) const TITLE_DOWNLOADING_NEW_VERSION: &str = "title-downloading-new-version";
+
+// ---------------- placeholders ----------------

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -1,0 +1,127 @@
+use std::collections::HashMap;
+
+use crate::i18n::{keys::*, LocaleTranslations, TranslationMap, TranslationValue};
+
+pub struct EnglishUSTranslations;
+
+impl TranslationMap for EnglishUSTranslations {
+    fn get_translations() -> LocaleTranslations {
+        let mut translations = HashMap::new();
+
+        // buttons
+        translations.insert(BUTTON_APPLY, TranslationValue::Text("Apply"));
+        translations.insert(BUTTON_DOWNLOAD, TranslationValue::Text("Download"));
+        translations.insert(
+            BUTTON_OPEN_LOG_DIRECTORY,
+            TranslationValue::Text("Open Log Directory"),
+        );
+        translations.insert(
+            BUTTON_SELECT_FOLDER,
+            TranslationValue::Text("Select Folder"),
+        );
+        translations.insert(BUTTON_STOP, TranslationValue::Text("Stop"));
+
+        // labels
+        translations.insert(
+            LABEL_AUTOMATICALLY_RETRIEVE_COORDINATES,
+            TranslationValue::Text("Automatically Retrieve Coordinates"),
+        );
+        translations.insert(
+            LABEL_AUTOMATICALLY_SWITCH_TO_DARK_MODE,
+            TranslationValue::Text("Automatically Switch to Dark Mode"),
+        );
+        translations.insert(
+            LABEL_CHECK_INTERVAL,
+            TranslationValue::Text("Check Interval"),
+        );
+        translations.insert(
+            LABEL_GITHUB_MIRROR_TEMPLATE,
+            TranslationValue::Text("GithubMirrorTemplate"),
+        );
+        translations.insert(
+            LABEL_LAUNCH_AT_STARTUP,
+            TranslationValue::Text("Launch at Startup"),
+        );
+        translations.insert(
+            LABEL_SET_LOCK_SCREEN_WALLPAPER_SIMULTANEOUSLY,
+            TranslationValue::Text("Set Lock Screen Wallpaper Simultaneously"),
+        );
+        translations.insert(
+            LABEL_THEMES_DIRECTORY,
+            TranslationValue::Text("Theme Directory"),
+        );
+        translations.insert(LABEL_VERSION, TranslationValue::Text("Version"));
+
+        // tooltips
+        translations.insert(
+            TOOLTIP_OPEN_THEMES_DIRECTORY,
+            TranslationValue::Text("Click it to open the themes directory."),
+        );
+        translations.insert(
+            TOOLTIP_CHECK_NEW_VERSION,
+            TranslationValue::Text("Click to check for new version"),
+        );
+        translations.insert(
+            TOOLTIP_NEW_VERSION_AVAILABLE,
+            TranslationValue::Text("New version available! Click this button to update."),
+        );
+        translations.insert(TOOLTIP_SETTINGS, TranslationValue::Text("Settings"));
+
+        // messages
+        translations.insert(
+            MESSAGE_CHANGE_THEMES_DIRECTORY,
+            TranslationValue::Template {
+                template: "Change the themes directory to: {{newThemesDirectory}}?",
+                params: &["newThemesDirectory"],
+            },
+        );
+        translations.insert(
+            MESSAGE_DISABLE_STARTUP_FAILED,
+            TranslationValue::Template {
+                template: "Failed to disable startup: \n${error}",
+                params: &["error"],
+            },
+        );
+        translations.insert(
+            MESSAGE_DOWNLOAD_FAILED,
+            TranslationValue::Template {
+                template:
+                    "${error}\n\nFor specific errors, please check the log: dwall_settings_lib.log",
+                params: &["error"],
+            },
+        );
+        translations.insert(
+            MESSAGE_STARTUP_FAILED,
+            TranslationValue::Template {
+                template: "Startup failed: \n${error}",
+                params: &["error"],
+            },
+        );
+        translations.insert(
+            MESSAGE_THEMES_DIRECTORY_MOVED,
+            TranslationValue::Template {
+                template: "The themes directory has been moved to: {{newThemesDirectory}}",
+                params: &["newThemesDirectory"],
+            },
+        );
+        translations.insert(
+            MESSAGE_VERSION_IS_THE_LATEST,
+            TranslationValue::Text("The current version is already the latest."),
+        );
+
+        // units
+        translations.insert(UNIT_SECOND, TranslationValue::Text("s"));
+
+        // titles
+        translations.insert(
+            TITLE_DOWNLOAD_FAILD,
+            TranslationValue::Text("Download Failed"),
+        );
+        translations.insert(
+            TITLE_DOWNLOADING_NEW_VERSION,
+            TranslationValue::Text("Downloading new version..."),
+        );
+
+        translations
+    }
+}

--- a/src-tauri/src/i18n/locales/mod.rs
+++ b/src-tauri/src/i18n/locales/mod.rs
@@ -1,0 +1,2 @@
+pub mod en_us;
+pub mod zh_cn;

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+
+use crate::i18n::{keys::*, LocaleTranslations, TranslationMap, TranslationValue};
+
+pub struct ChineseSimplifiedTranslations;
+
+impl TranslationMap for ChineseSimplifiedTranslations {
+    fn get_translations() -> LocaleTranslations {
+        let mut translations = HashMap::new();
+
+        // buttons
+        translations.insert(BUTTON_APPLY, TranslationValue::Text("应用"));
+        translations.insert(BUTTON_DOWNLOAD, TranslationValue::Text("下载"));
+        translations.insert(
+            BUTTON_OPEN_LOG_DIRECTORY,
+            TranslationValue::Text("打开日志文件夹"),
+        );
+        translations.insert(BUTTON_SELECT_FOLDER, TranslationValue::Text("修改"));
+        translations.insert(BUTTON_STOP, TranslationValue::Text("停止"));
+
+        // labels
+        translations.insert(
+            LABEL_AUTOMATICALLY_RETRIEVE_COORDINATES,
+            TranslationValue::Text("自动获取坐标"),
+        );
+        translations.insert(
+            LABEL_AUTOMATICALLY_SWITCH_TO_DARK_MODE,
+            TranslationValue::Text("自动切换暗色模式"),
+        );
+        translations.insert(LABEL_CHECK_INTERVAL, TranslationValue::Text("检测间隔"));
+        translations.insert(
+            LABEL_GITHUB_MIRROR_TEMPLATE,
+            TranslationValue::Text("Github 镜像模板"),
+        );
+        translations.insert(LABEL_LAUNCH_AT_STARTUP, TranslationValue::Text("开机自启"));
+        translations.insert(
+            LABEL_SET_LOCK_SCREEN_WALLPAPER_SIMULTANEOUSLY,
+            TranslationValue::Text("同时设置锁屏壁纸"),
+        );
+        translations.insert(LABEL_THEMES_DIRECTORY, TranslationValue::Text("主题文件夹"));
+        translations.insert(LABEL_VERSION, TranslationValue::Text("版本号"));
+
+        // tooltips
+        translations.insert(
+            TOOLTIP_OPEN_THEMES_DIRECTORY,
+            TranslationValue::Text("点击打开主题文件夹"),
+        );
+        translations.insert(
+            TOOLTIP_CHECK_NEW_VERSION,
+            TranslationValue::Text("点击检查新版本"),
+        );
+        translations.insert(
+            TOOLTIP_NEW_VERSION_AVAILABLE,
+            TranslationValue::Text("发现新版本，点击更新"),
+        );
+        translations.insert(TOOLTIP_SETTINGS, TranslationValue::Text("设置"));
+
+        // messages
+        translations.insert(
+            MESSAGE_CHANGE_THEMES_DIRECTORY,
+            TranslationValue::Template {
+                template: "修改主题文件夹为：{{newThemesDirectory}}？",
+                params: &["newThemesDirectory"],
+            },
+        );
+        translations.insert(
+            MESSAGE_DISABLE_STARTUP_FAILED,
+            TranslationValue::Template {
+                template: "关闭开机自启失败：\n${error}",
+                params: &["error"],
+            },
+        );
+        translations.insert(
+            MESSAGE_DOWNLOAD_FAILED,
+            TranslationValue::Template {
+                template: "${error}\n\n具体错误请查看日志文件：dwall_settings_lib.log",
+                params: &["error"],
+            },
+        );
+        translations.insert(
+            MESSAGE_STARTUP_FAILED,
+            TranslationValue::Template {
+                template: "设置开机自启失败：\n${error}",
+                params: &["error"],
+            },
+        );
+        translations.insert(
+            MESSAGE_THEMES_DIRECTORY_MOVED,
+            TranslationValue::Template {
+                template: "主题文件夹已改为：{{newThemesDirectory}}",
+                params: &["newThemesDirectory"],
+            },
+        );
+        translations.insert(
+            MESSAGE_VERSION_IS_THE_LATEST,
+            TranslationValue::Text("当前已是最新版本"),
+        );
+
+        // titles
+        translations.insert(TITLE_DOWNLOAD_FAILD, TranslationValue::Text("下载失败"));
+        translations.insert(
+            TITLE_DOWNLOADING_NEW_VERSION,
+            TranslationValue::Text("正在下载新版本..."),
+        );
+
+        translations
+    }
+}

--- a/src-tauri/src/i18n/mod.rs
+++ b/src-tauri/src/i18n/mod.rs
@@ -1,0 +1,138 @@
+use std::str::FromStr;
+use std::sync::LazyLock;
+use std::{collections::HashMap, sync::RwLock};
+
+use serde::Serialize;
+
+use self::locales::en_us::EnglishUSTranslations;
+use self::locales::zh_cn::ChineseSimplifiedTranslations;
+
+mod keys;
+mod locales;
+mod utils;
+
+static TRANSLATIONS: LazyLock<RwLock<HashMap<&'static str, LocaleTranslations>>> =
+    LazyLock::new(|| {
+        RwLock::new({
+            let mut m = HashMap::new();
+
+            // 英文必须实现所有的翻译键
+            m.insert("en-US", EnglishUSTranslations::get_translations());
+
+            // 其他语言可以只实现部分键
+            m.insert("zh-CN", ChineseSimplifiedTranslations::get_translations());
+
+            m
+        })
+    });
+
+#[derive(Debug, Clone, Copy, Default)]
+pub enum Language {
+    #[default]
+    EnglishUS,
+    // EnglishGB,
+    ChineseSimplified,
+    // ChineseTraditionalTW,
+    // ChineseTraditionalHK,
+}
+
+impl FromStr for Language {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en-US" => Ok(Language::EnglishUS),
+            "zh-CN" => Ok(Language::ChineseSimplified),
+            _ => Err(format!("Unsupported language identifier: {}", s)),
+        }
+    }
+}
+
+impl Language {
+    pub fn id(&self) -> &'static str {
+        match self {
+            Language::EnglishUS => "en-US",
+            // LanguageVariant::EnglishGB => "en-GB",
+            Language::ChineseSimplified => "zh-CN",
+            // LanguageVariant::ChineseTraditionalTW => "zh-TW",
+            // LanguageVariant::ChineseTraditionalHK => "zh-HK",
+        }
+    }
+
+    pub fn native_name(&self) -> &'static str {
+        match self {
+            Language::EnglishUS => "American English",
+            // LanguageVariant::EnglishGB => "British English",
+            Language::ChineseSimplified => "简体中文",
+            // LanguageVariant::ChineseTraditionalTW => "繁體中文（台灣）",
+            // LanguageVariant::ChineseTraditionalHK => "繁體中文（香港）",
+        }
+    }
+
+    // pub fn country_code(&self) -> &'static str {
+    //     match self {
+    //         Language::EnglishUS | Language::ChineseSimplified => "US",
+    //         // LanguageVariant::EnglishGB => "GB",
+    //         Language::ChineseSimplified => "CN",
+    //         // LanguageVariant::ChineseTraditionalTW => "TW",
+    //         // LanguageVariant::ChineseTraditionalHK => "HK",
+    //     }
+    // }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(untagged)]
+pub enum TranslationValue {
+    Text(&'static str),
+    Template {
+        template: &'static str,
+        params: &'static [&'static str],
+    },
+}
+
+pub type LocaleTranslations = HashMap<&'static str, TranslationValue>;
+
+pub trait TranslationMap {
+    fn get_translations() -> LocaleTranslations;
+}
+
+thread_local! {
+    static CURRENT_LANGUAGE: std::cell::RefCell<Language> = std::cell::RefCell::new(Language::from_str(&self::utils::get_user_preferred_language().unwrap_or("en-US".to_string())).unwrap_or(Language::default()));
+}
+
+pub fn get_current_language() -> Language {
+    CURRENT_LANGUAGE.with(|lang| lang.borrow().clone())
+}
+
+// pub fn set_language(language_id: &str) -> Result<(), String> {
+//     let language_id = Language::from_str(language_id)?;
+//     CURRENT_LANGUAGE.with(|current_lang| {
+//         *current_lang.borrow_mut() = language_id;
+//     });
+//     Ok(())
+// }
+
+#[tauri::command]
+pub fn get_translations() -> LocaleTranslations {
+    let current_lang = get_current_language();
+    info!("Current language: {}", current_lang.native_name());
+
+    let translations = TRANSLATIONS.read().unwrap();
+
+    let en_us_translations = translations
+        .get("en-US")
+        .expect("English translations must be defined");
+
+    let mut locale_translations = translations
+        .get(&current_lang.id())
+        .cloned()
+        .unwrap_or_default();
+
+    for (key, value) in en_us_translations.iter() {
+        if !locale_translations.contains_key(*key) {
+            locale_translations.insert(*key, value.clone());
+        }
+    }
+
+    locale_translations
+}

--- a/src-tauri/src/i18n/utils.rs
+++ b/src-tauri/src/i18n/utils.rs
@@ -1,0 +1,37 @@
+use windows::{core::PWSTR, Win32::Globalization::GetUserPreferredUILanguages};
+
+use crate::error::DwallSettingsResult;
+
+pub(super) fn get_user_preferred_language() -> DwallSettingsResult<String> {
+    let mut num_languages: u32 = 0;
+    let mut buffer_size: u32 = 0;
+
+    unsafe {
+        GetUserPreferredUILanguages(
+            0,                           // dwflags, 0 means no special options
+            &mut num_languages,          // Number of languages (output)
+            PWSTR(std::ptr::null_mut()), // No buffer yet, to get the size first
+            &mut buffer_size,
+        )?
+    };
+
+    let mut buffer: Vec<u16> = vec![0; buffer_size as usize];
+    unsafe {
+        GetUserPreferredUILanguages(
+            0,                                      // dwflags, 0 means no special options
+            &mut num_languages,                     // Number of languages (output)
+            PWSTR(buffer.as_mut_ptr() as *mut u16), // The buffer to hold the languages
+            &mut buffer_size,                       // Buffer size (output)
+        )?;
+    }
+
+    let languages = buffer
+        .split(|&c| c == 0)
+        .filter_map(|chunk| String::from_utf16(chunk).ok())
+        .collect::<Vec<String>>();
+
+    let language = &languages[0];
+
+    info!("Succesfully got user preferred language: {}", language);
+    Ok(language.to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ use crate::cache::get_or_save_cached_image;
 use crate::download::download_theme_and_extract;
 use crate::error::DwallSettingsResult;
 use crate::fs::move_themes_directory;
+use crate::i18n::get_translations;
 use crate::postion::request_location_permission;
 use crate::process_manager::{find_daemon_process, kill_daemon};
 use crate::setup::setup_app;
@@ -23,6 +24,7 @@ mod cache;
 mod download;
 mod error;
 mod fs;
+mod i18n;
 mod postion;
 mod process_manager;
 mod setup;
@@ -216,7 +218,8 @@ pub fn run() -> DwallSettingsResult<()> {
             set_titlebar_color_mode,
             move_themes_directory,
             kill_daemon,
-            get_or_save_cached_image
+            get_or_save_cached_image,
+            get_translations
         ]);
 
     if cfg!(debug_assertions) {


### PR DESCRIPTION
- Added `Win32_Globalization` feature to `Cargo.toml` for Windows globalization support.
- Created new files for internationalization (i18n) under `src-tauri/src/i18n/`:
  - `keys.rs`: Contains translation keys for buttons, labels, tooltips, messages, units, and titles.
  - `locales/mod.rs`: Module file for locale-specific translations.
  - `locales/en_us.rs`: English (US) translations.
  - `locales/zh_cn.rs`: Chinese (Simplified) translations.
  - `mod.rs`: Main module for i18n, including language enum, translation map, and translation retrieval logic.
  - `utils.rs`: Utility functions for retrieving user preferred language on Windows.
- Updated `lib.rs` to include i18n module and expose `get_translations` command.