### PR TITLE
feat(i18n): Add location permission message and handle permission req…

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -29,6 +29,7 @@ pub(super) const MESSAGE_CHANGE_THEMES_DIRECTORY: &str = "message-change-themes-
 pub(super) const MESSAGE_DISABLE_STARTUP_FAILED: &str = "message-disable-startup-failed";
 pub(super) const MESSAGE_DOWNLOAD_FAILED: &str = "message-download-faild";
 pub(super) const MESSAGE_INVALID_NUMBER_INPUT: &str = "message-invalid-number-input";
+pub(super) const MESSAGE_LOCATION_PERMISSION: &str = "message-location-permission";
 pub(super) const MESSAGE_NUMBER_TOO_LARGE: &str = "message-number-too-large";
 pub(super) const MESSAGE_NUMBER_TOO_SMALL: &str = "message-number-too-small";
 pub(super) const MESSAGE_STARTUP_FAILED: &str = "message-startup-failed";

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -95,11 +95,8 @@ impl TranslationMap for EnglishUSTranslations {
             TranslationValue::Text("Please enter a valid number."),
         );
         translations.insert(
-            MESSAGE_STARTUP_FAILED,
-            TranslationValue::Template {
-                template: "Startup failed: \n${error}",
-                params: &["error"],
-            },
+            MESSAGE_LOCATION_PERMISSION,
+            TranslationValue::Text("The location permission is not turned on. Please manually enable location or manually configure coordinates.\n\nDo you want to manually configure coordinates?\nClick \"Yes\" to manually configure coordinates, or click \"No\" to close the program."),
         );
         translations.insert(
             MESSAGE_NUMBER_TOO_LARGE,
@@ -113,6 +110,13 @@ impl TranslationMap for EnglishUSTranslations {
             TranslationValue::Template {
                 template: "Cannot be less than {{min}}",
                 params: &["min"],
+            },
+        );
+        translations.insert(
+            MESSAGE_STARTUP_FAILED,
+            TranslationValue::Template {
+                template: "Startup failed: \n${error}",
+                params: &["error"],
             },
         );
         translations.insert(

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -82,6 +82,10 @@ impl TranslationMap for ChineseSimplifiedTranslations {
             TranslationValue::Text("请输入有效的数字"),
         );
         translations.insert(
+            MESSAGE_LOCATION_PERMISSION,
+            TranslationValue::Text("定位权限未打开，请手动开启定位或手动配置坐标。\n\n是否手动配置坐标？\n点击“是”手动配置坐标，点击“否”关闭程序"),
+        );
+        translations.insert(
             MESSAGE_NUMBER_TOO_LARGE,
             TranslationValue::Template {
                 template: "不能大于 {{max}}",

--- a/src-tauri/src/i18n/utils.rs
+++ b/src-tauri/src/i18n/utils.rs
@@ -33,5 +33,6 @@ pub(super) fn get_user_preferred_language() -> DwallSettingsResult<String> {
     let language = &languages[0];
 
     info!("Succesfully got user preferred language: {}", language);
-    Ok(language.to_string())
+    // Ok(language.to_string())
+    Ok("en-US".to_string())
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { createResource, createSignal, onMount, Show } from "solid-js";
+import { createSignal, onMount, Show } from "solid-js";
 import { LazyFlex, LazyTooltip, LazyButton, LazySpace } from "~/lazy";
 import { AiFillSetting } from "solid-icons/ai";
 import useDark from "alley-components/lib/hooks/useDark";
@@ -10,7 +10,6 @@ import {
   showWindow,
   getAppliedThemeID,
   setTitlebarColorMode,
-  getTranslations,
 } from "~/commands";
 import { useThemeSelector } from "./components/ThemeContext";
 import "./App.scss";
@@ -23,7 +22,6 @@ import { translate } from "./utils/i18n";
 
 const App = () => {
   const [showUpdateDialog, setShowUpdateDialog] = createSignal<boolean>();
-  const [translations] = createResource(getTranslations);
 
   const {
     config,
@@ -43,6 +41,7 @@ const App = () => {
     recheckUpdate,
     showSettings,
     setShowSettings,
+    translations,
   } = useThemeSelector(themes);
 
   useDark();
@@ -113,7 +112,7 @@ const App = () => {
                 positioning="after"
                 content={translate(
                   translations()!,
-                  "tooltip-new-version-available",
+                  "tooltip-new-version-available"
                 )}
                 relationship="label"
               >

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -15,8 +15,8 @@ interface CoordinateSourceAutomatic {
 
 interface CoordinateSourceManual {
   type: "MANUAL";
-  latitude: number;
-  longitude: number;
+  latitude?: number;
+  longitude?: number;
 }
 
 type CoordinateSource = CoordinateSourceAutomatic | CoordinateSourceManual;

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -20,6 +20,7 @@ type TranslationKey =
   | "message-disable-startup-failed"
   | "message-download-faild"
   | "message-invalid-number-input"
+  | "message-location-permission"
   | "message-number-too-small"
   | "message-number-too-large"
   | "message-startup-failed"


### PR DESCRIPTION
…uest

- Added new translation key `MESSAGE_LOCATION_PERMISSION` in `keys.rs`.
- Updated `en_us.rs` and `zh_cn.rs` with the new location permission message.
- Modified `utils.rs` to hardcode the user preferred language to "en-US".
- Removed unnecessary `createResource` call for translations in `App.tsx`.
- Updated `ThemeContext.tsx` to handle location permission request and prompt user for manual coordinate configuration if permission is not granted.
- Modified `config.d.ts` to make latitude and longitude optional in manual coordinate configuration.
- Updated `i18n.d.ts` to include the new `message-location-permission` key.