### PR TITLE
feat: Add latitude and longitude placeholders and update components

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -44,3 +44,5 @@ pub(super) const TITLE_DOWNLOAD_FAILD: &str = "title-download-faild";
 pub(super) const TITLE_DOWNLOADING_NEW_VERSION: &str = "title-downloading-new-version";
 
 // ---------------- placeholders ----------------
+pub(super) const PLACEHOLDER_LATITUDE: &str = "placeholder-latitude";
+pub(super) const PLACEHOLDER_LONGITUDE: &str = "placeholder-longitude";

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -144,6 +144,10 @@ impl TranslationMap for EnglishUSTranslations {
             TranslationValue::Text("Downloading new version..."),
         );
 
+        // placeholders
+        translations.insert(PLACEHOLDER_LATITUDE, TranslationValue::Text("latitude"));
+        translations.insert(PLACEHOLDER_LONGITUDE, TranslationValue::Text("longitude"));
+
         translations
     }
 }

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -125,6 +125,10 @@ impl TranslationMap for ChineseSimplifiedTranslations {
             TranslationValue::Text("正在下载新版本..."),
         );
 
+        // placeholders
+        translations.insert(PLACEHOLDER_LATITUDE, TranslationValue::Text("纬度"));
+        translations.insert(PLACEHOLDER_LONGITUDE, TranslationValue::Text("经度"));
+
         translations
     }
 }

--- a/src/components/Settings/CoordinateSource.tsx
+++ b/src/components/Settings/CoordinateSource.tsx
@@ -34,7 +34,6 @@ const CoordinateInput = (props: CoordinateInputProps) => {
       size="small"
       suffix="°"
       appearance="underline"
-      style={{ width: "72px" }}
       autofocus={props.autofocus}
     />
   );
@@ -97,20 +96,27 @@ const CoordinateSource = () => {
     refetchConfig();
   };
 
+  const latitudePlaceholder = translate(
+    translations()!,
+    "placeholder-latitude",
+  );
+  const longitudePlaceholder = translate(
+    translations()!,
+    "placeholder-longitude",
+  );
+
   return (
     <SettingsItem
+      layout="horizontal"
       label={translate(
         translations()!,
         "label-automatically-retrieve-coordinates",
       )}
-    >
-      <LazySpace gap={auto() ? 0 : 8}>
-        <LazySwitch checked={auto()} onChange={onSwitchCoordinateSource} />
-
+      extra={
         <Show when={!auto()}>
-          <LazySpace gap={8}>
+          <LazySpace gap={16} justify="end">
             <CoordinateInput
-              placeholder="经度"
+              placeholder={longitudePlaceholder}
               min={-180.0}
               max={180.0}
               defaultValue={position().longitude}
@@ -124,7 +130,7 @@ const CoordinateSource = () => {
             />
 
             <CoordinateInput
-              placeholder="纬度"
+              placeholder={latitudePlaceholder}
               min={-90.0}
               max={90.0}
               defaultValue={position().latitude}
@@ -144,6 +150,10 @@ const CoordinateSource = () => {
             />
           </LazySpace>
         </Show>
+      }
+    >
+      <LazySpace gap={auto() ? 0 : 8}>
+        <LazySwitch checked={auto()} onChange={onSwitchCoordinateSource} />
       </LazySpace>
     </SettingsItem>
   );

--- a/src/components/Settings/GithubMirror.tsx
+++ b/src/components/Settings/GithubMirror.tsx
@@ -22,6 +22,7 @@ const GithubMirror = () => {
 
   return (
     <SettingsItem
+      layout="vertical"
       label={translate(translations()!, "label-github-mirror-template")}
       vertical
     >

--- a/src/components/Settings/ThemesDirectory.tsx
+++ b/src/components/Settings/ThemesDirectory.tsx
@@ -44,6 +44,7 @@ const ThemesDirectory = () => {
 
   return (
     <SettingsItem
+      layout="vertical"
       label={translate(translations()!, "label-themes-directory")}
       vertical
     >

--- a/src/components/Settings/item.tsx
+++ b/src/components/Settings/item.tsx
@@ -1,39 +1,75 @@
 import { children, type JSXElement } from "solid-js";
 import { LazyFlex, LazyLabel } from "~/lazy";
 
-interface SettingsItemProps {
+interface BaseProps {
   label: string;
   children: JSXElement;
-  vertical?: boolean;
 }
 
+interface VerticalLayout {
+  layout: "vertical";
+  vertical: true;
+  extra?: never;
+}
+
+interface HorizontalLayout {
+  layout: "horizontal";
+  vertical?: never;
+  extra?: JSXElement;
+}
+
+interface DefaultLayout {
+  layout?: never;
+  vertical?: never;
+  extra?: never;
+}
+
+type LayoutConfig = VerticalLayout | HorizontalLayout | DefaultLayout;
+type SettingsItemProps = BaseProps & LayoutConfig;
+
+const labelStyles = {
+  display: "flex",
+  "justify-items": "center",
+  "align-items": "center",
+} as const;
+
 const SettingsItem = (props: SettingsItemProps) => {
-  const resolved = children(() =>
-    props.vertical ? (
-      <LazyFlex direction="vertical" gap={8}>
-        <LazyLabel weight="semibold">{props.label}</LazyLabel>
+  const renderLabel = children(() => (
+    <LazyLabel weight="semibold" style={labelStyles}>
+      {props.label}
+    </LazyLabel>
+  ));
 
-        {props.children}
-      </LazyFlex>
-    ) : (
+  const renderContent = children(() => {
+    if (props.layout === "vertical") {
+      return (
+        <LazyFlex direction="vertical" gap={8}>
+          {renderLabel()}
+          {props.children}
+        </LazyFlex>
+      );
+    }
+
+    const mainContent = (
       <LazyFlex justify="between">
-        <LazyLabel
-          weight="semibold"
-          style={{
-            display: "flex",
-            "justify-items": "center",
-            "align-items": "center",
-          }}
-        >
-          {props.label}
-        </LazyLabel>
-
+        {renderLabel()}
         {props.children}
       </LazyFlex>
-    ),
-  );
+    );
 
-  return <>{resolved}</>;
+    if (props.layout === "horizontal" && props.extra) {
+      return (
+        <LazyFlex direction="vertical" gap={8}>
+          {mainContent}
+          {props.extra}
+        </LazyFlex>
+      );
+    }
+
+    return mainContent;
+  });
+
+  return <>{renderContent()}</>;
 };
 
 export default SettingsItem;

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -26,6 +26,8 @@ type TranslationKey =
   | "message-startup-failed"
   | "message-themes-directory-moved"
   | "message-version-is-the-latest"
+  | "placeholder-latitude"
+  | "placeholder-longitude"
   | "unit-second"
   | "title-download-faild"
   | "title-downloading-new-version";


### PR DESCRIPTION
- Added `PLACEHOLDER_LATITUDE` and `PLACEHOLDER_LONGITUDE` translation keys in `keys.rs`.
- Updated `en_us.rs` and `zh_cn.rs` to include translations for latitude and longitude placeholders.
- Modified `CoordinateSource.tsx` to use the new placeholders for latitude and longitude inputs.
- Refactored `SettingsItem.tsx` to support vertical and horizontal layouts, improving component structure and reusability.
- Updated `GithubMirror.tsx` and `ThemesDirectory.tsx` to use the new vertical layout in `SettingsItem`.