### PR TITLE
fix(i18n): return user preferred language instead of hardcoded value

### DIFF
--- a/src-tauri/src/i18n/utils.rs
+++ b/src-tauri/src/i18n/utils.rs
@@ -33,6 +33,5 @@ pub(super) fn get_user_preferred_language() -> DwallSettingsResult<String> {
     let language = &languages[0];
 
     info!("Succesfully got user preferred language: {}", language);
-    // Ok(language.to_string())
-    Ok("en-US".to_string())
+    Ok(language.to_string())
 }


### PR DESCRIPTION
Previously, the function `get_user_preferred_language` was returning a hardcoded value of "en-US" instead of the user's actual preferred language. This commit fixes the function to return the user's preferred language as determined by the `languages` array.