### PR TITLE
style(Menu): Refactor menu item styles and add hover/active effects

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,5 +1,5 @@
 .menu-item {
-  --menu-item-color-shadow: #00000085;
+  --menu-item-color-shadow: rgba(0, 0, 0, 0.3);
 
   padding: 4px;
   border-radius: 5px;
@@ -7,53 +7,55 @@
   width: 64px;
   display: flex;
   align-items: center;
+  position: relative;
+  transition: all 0.2s ease-in-out;
+  background: var(--colorNeutralBackground6);
 
   &:hover {
-    box-shadow: 0 0 5px 1px var(--menu-item-color-shadow);
-  }
-
-  &.active {
-    box-shadow: 0 0 5px 1px var(--menu-item-color-shadow);
-  }
-
-  &.applied {
-    position: relative;
-
-    &::before {
-      content: "";
-      color: #fff;
-      font-weight: bold;
-      font-size: 0.8rem;
-      position: absolute;
-      top: 4px;
-      left: 4px;
-      width: 24px;
-      height: 24px;
-      background-color: var(--colorStatusSuccessBackground3);
-      clip-path: polygon(0 0, 100% 0, 0 100%);
-      z-index: 1;
-    }
+    background: var(--colorNeutralCardBackgroundHover);
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px var(--menu-item-color-shadow);
 
     &::after {
-      content: "✓";
-      font-weight: bold;
-      position: absolute;
-      top: 4px;
-      left: 7px;
-      color: white;
-      font-size: 0.8rem;
-      z-index: 2;
+      opacity: 1;
     }
   }
-}
 
-@media (prefers-color-scheme: dark) {
-  .menu-item {
-    --menu-item-color-shadow: #61616185;
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: 0;
+    border-radius: 5px;
+    background: linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.1),
+      rgba(255, 255, 255, 0.05)
+    );
+    transition: opacity 0.2s ease-in-out;
+    pointer-events: none;
+  }
 
-    &.active,
-    &:hover {
-      background-color: #ffffff14;
+  &-active {
+    background: var(--colorNeutralCardBackgroundHover);
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px var(--menu-item-color-shadow);
+
+    &::after {
+      opacity: 1;
+    }
+  }
+
+  &-applied {
+    position: relative;
+
+    &-badge {
+      position: absolute;
+      right: 4px;
+      bottom: 2px;
     }
   }
 }

--- a/src/components/ThemeMenu.tsx
+++ b/src/components/ThemeMenu.tsx
@@ -1,6 +1,7 @@
 import { children } from "solid-js";
-import { LazyFlex, LazyTooltip } from "~/lazy";
+import { LazyBadge, LazyFlex, LazyTooltip } from "~/lazy";
 import Image from "./Image";
+import { BsCheckLg } from "solid-icons/bs";
 
 interface ThemeMenuProps {
   themes: ThemeItem[];
@@ -18,8 +19,8 @@ export const ThemeMenu = (props: ThemeMenuProps) => {
         onClick={() => props.onMenuItemClick(idx, heights[item.id])}
         classList={{
           "menu-item": true,
-          active: idx === props.index,
-          applied: item.id === props.appliedThemeID,
+          "menu-item-active": idx === props.index,
+          "menu-item-applied": item.id === props.appliedThemeID,
         }}
       >
         <LazyTooltip positioning="after" content={item.id} relationship="label">
@@ -34,6 +35,16 @@ export const ThemeMenu = (props: ThemeMenuProps) => {
             }}
           />
         </LazyTooltip>
+        {item.id === props.appliedThemeID && (
+          <div class="menu-item-applied-badge">
+            <LazyBadge
+              shape="square"
+              icon={<BsCheckLg />}
+              color="success"
+              size="small"
+            />
+          </div>
+        )}
       </div>
     )),
   );


### PR DESCRIPTION
- Updated the shadow color variable to use `rgba` for better readability.
- Added `position: relative` and `transition` properties to `.menu-item`.
- Enhanced hover and active states with background color, transform, and shadow effects.
- Introduced a pseudo-element (`&::after`) for a gradient overlay on hover.
- Replaced `.active` and `.applied` classes with `.menu-item-active` and `.menu-item-applied`.
- Added a badge component with a check icon for applied themes in `ThemeMenu.tsx`.
- Removed unused media query for dark mode adjustments.