### PR TITLE
style: Align badge shape with applied menu item's rounded corners

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -60,6 +60,6 @@
   }
 
   img {
-    border-radius: 5px;
+    border-radius: 4px;
   }
 }

--- a/src/components/ThemeMenu.tsx
+++ b/src/components/ThemeMenu.tsx
@@ -38,7 +38,7 @@ export const ThemeMenu = (props: ThemeMenuProps) => {
         {item.id === props.appliedThemeID && (
           <div class="menu-item-applied-badge">
             <LazyBadge
-              shape="square"
+              shape="rounded"
               icon={<BsCheckLg />}
               color="success"
               size="small"


### PR DESCRIPTION
- Updated `LazyBadge` shape from `square` to `rounded` in `ThemeMenu.tsx` to match the rounded corners of applied menu items
- Adjusted `border-radius` of `img` elements from `5px` to `4px` in `App.scss` for consistency