### PR TITLE
fix(i18n): Correct template syntax in translation files

### DIFF
--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -78,7 +78,7 @@ impl TranslationMap for EnglishUSTranslations {
         translations.insert(
             MESSAGE_DISABLE_STARTUP_FAILED,
             TranslationValue::Template {
-                template: "Failed to disable startup: \n${error}",
+                template: "Failed to disable startup: \n{{error}}",
                 params: &["error"],
             },
         );
@@ -86,7 +86,7 @@ impl TranslationMap for EnglishUSTranslations {
             MESSAGE_DOWNLOAD_FAILED,
             TranslationValue::Template {
                 template:
-                    "${error}\n\nFor specific errors, please check the log: dwall_settings_lib.log",
+                    "{{error}}\n\nFor specific errors, please check the log: dwall_settings_lib.log",
                 params: &["error"],
             },
         );
@@ -115,7 +115,7 @@ impl TranslationMap for EnglishUSTranslations {
         translations.insert(
             MESSAGE_STARTUP_FAILED,
             TranslationValue::Template {
-                template: "Startup failed: \n${error}",
+                template: "Startup failed: \n{{error}}",
                 params: &["error"],
             },
         );

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -66,14 +66,14 @@ impl TranslationMap for ChineseSimplifiedTranslations {
         translations.insert(
             MESSAGE_DISABLE_STARTUP_FAILED,
             TranslationValue::Template {
-                template: "关闭开机自启失败：\n${error}",
+                template: "关闭开机自启失败：\n{{error}}",
                 params: &["error"],
             },
         );
         translations.insert(
             MESSAGE_DOWNLOAD_FAILED,
             TranslationValue::Template {
-                template: "${error}\n\n具体错误请查看日志文件：dwall_settings_lib.log",
+                template: "{{error}}\n\n具体错误请查看日志文件：dwall_settings_lib.log",
                 params: &["error"],
             },
         );
@@ -102,7 +102,7 @@ impl TranslationMap for ChineseSimplifiedTranslations {
         translations.insert(
             MESSAGE_STARTUP_FAILED,
             TranslationValue::Template {
-                template: "设置开机自启失败：\n${error}",
+                template: "设置开机自启失败：\n{{error}}",
                 params: &["error"],
             },
         );


### PR DESCRIPTION
Fixed the template syntax by changing ${error} to {{error}} in both en_us.rs and zh_cn.rs translation files. This resolves the template format error and ensures proper rendering of error messages in the application.