### PR TITLE
feat(i18n): Add support for Traditional Chinese (Hong Kong) locale

### DIFF
--- a/src-tauri/src/i18n/locales/mod.rs
+++ b/src-tauri/src/i18n/locales/mod.rs
@@ -1,2 +1,3 @@
 pub mod en_us;
 pub mod zh_cn;
+pub mod zh_hk;

--- a/src-tauri/src/i18n/locales/zh_hk.rs
+++ b/src-tauri/src/i18n/locales/zh_hk.rs
@@ -1,0 +1,134 @@
+use std::collections::HashMap;
+
+use crate::i18n::{keys::*, LocaleTranslations, TranslationMap, TranslationValue};
+
+pub struct ChineseTraditionalHKTranslations;
+
+impl TranslationMap for ChineseTraditionalHKTranslations {
+    fn get_translations() -> LocaleTranslations {
+        let mut translations = HashMap::new();
+
+        // buttons
+        translations.insert(BUTTON_APPLY, TranslationValue::Text("應用"));
+        translations.insert(BUTTON_DOWNLOAD, TranslationValue::Text("下載"));
+        translations.insert(
+            BUTTON_OPEN_LOG_DIRECTORY,
+            TranslationValue::Text("打開日誌資料夾"),
+        );
+        translations.insert(BUTTON_SELECT_FOLDER, TranslationValue::Text("修改"));
+        translations.insert(BUTTON_STOP, TranslationValue::Text("停止"));
+
+        // labels
+        translations.insert(
+            LABEL_AUTOMATICALLY_RETRIEVE_COORDINATES,
+            TranslationValue::Text("自動獲取坐標"),
+        );
+        translations.insert(
+            LABEL_AUTOMATICALLY_SWITCH_TO_DARK_MODE,
+            TranslationValue::Text("自動切換暗色模式"),
+        );
+        translations.insert(LABEL_CHECK_INTERVAL, TranslationValue::Text("檢測間隔"));
+        translations.insert(
+            LABEL_GITHUB_MIRROR_TEMPLATE,
+            TranslationValue::Text("Github 鏡像模板"),
+        );
+        translations.insert(LABEL_LAUNCH_AT_STARTUP, TranslationValue::Text("開機自啟"));
+        translations.insert(
+            LABEL_SET_LOCK_SCREEN_WALLPAPER_SIMULTANEOUSLY,
+            TranslationValue::Text("同時設定鎖屏壁紙"),
+        );
+        translations.insert(LABEL_THEMES_DIRECTORY, TranslationValue::Text("主題資料夾"));
+        translations.insert(LABEL_VERSION, TranslationValue::Text("版本號"));
+
+        // tooltips
+        translations.insert(
+            TOOLTIP_OPEN_THEMES_DIRECTORY,
+            TranslationValue::Text("點擊打開主題資料夾"),
+        );
+        translations.insert(
+            TOOLTIP_CHECK_NEW_VERSION,
+            TranslationValue::Text("點擊檢查新版本"),
+        );
+        translations.insert(
+            TOOLTIP_NEW_VERSION_AVAILABLE,
+            TranslationValue::Text("發現新版本，點擊更新"),
+        );
+        translations.insert(TOOLTIP_SETTINGS, TranslationValue::Text("設置"));
+
+        // messages
+        translations.insert(
+            MESSAGE_CHANGE_THEMES_DIRECTORY,
+            TranslationValue::Template {
+                template: "修改主題資料夾為：{{newThemesDirectory}}？",
+                params: &["newThemesDirectory"],
+            },
+        );
+        translations.insert(
+            MESSAGE_DISABLE_STARTUP_FAILED,
+            TranslationValue::Template {
+                template: "關閉開機自啟失敗：\n{{error}}",
+                params: &["error"],
+            },
+        );
+        translations.insert(
+            MESSAGE_DOWNLOAD_FAILED,
+            TranslationValue::Template {
+                template: "{{error}}\n\n具體錯誤請查看日誌檔案：dwall_settings_lib.log",
+                params: &["error"],
+            },
+        );
+        translations.insert(
+            MESSAGE_INVALID_NUMBER_INPUT,
+            TranslationValue::Text("請輸入有效的數字"),
+        );
+        translations.insert(
+            MESSAGE_LOCATION_PERMISSION,
+            TranslationValue::Text("定位權限未開啟，請手動開啟定位或手動配置坐標。\n\n是否手動配置坐標？\n點擊「是」手動配置坐標，點擊「否」關閉程式"),
+        );
+        translations.insert(
+            MESSAGE_NUMBER_TOO_LARGE,
+            TranslationValue::Template {
+                template: "不能大於 {{max}}",
+                params: &["max"],
+            },
+        );
+        translations.insert(
+            MESSAGE_NUMBER_TOO_SMALL,
+            TranslationValue::Template {
+                template: "不能小於 {{min}}",
+                params: &["min"],
+            },
+        );
+        translations.insert(
+            MESSAGE_STARTUP_FAILED,
+            TranslationValue::Template {
+                template: "設定開機自啟失敗：\n{{error}}",
+                params: &["error"],
+            },
+        );
+        translations.insert(
+            MESSAGE_THEMES_DIRECTORY_MOVED,
+            TranslationValue::Template {
+                template: "主題資料夾已改為：{{newThemesDirectory}}",
+                params: &["newThemesDirectory"],
+            },
+        );
+        translations.insert(
+            MESSAGE_VERSION_IS_THE_LATEST,
+            TranslationValue::Text("當前已是最新版本"),
+        );
+
+        // titles
+        translations.insert(TITLE_DOWNLOAD_FAILD, TranslationValue::Text("下載失敗"));
+        translations.insert(
+            TITLE_DOWNLOADING_NEW_VERSION,
+            TranslationValue::Text("正在下載新版本..."),
+        );
+
+        // placeholders
+        translations.insert(PLACEHOLDER_LATITUDE, TranslationValue::Text("緯度"));
+        translations.insert(PLACEHOLDER_LONGITUDE, TranslationValue::Text("經度"));
+
+        translations
+    }
+}

--- a/src-tauri/src/i18n/mod.rs
+++ b/src-tauri/src/i18n/mod.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 
 use self::locales::en_us::EnglishUSTranslations;
 use self::locales::zh_cn::ChineseSimplifiedTranslations;
+use self::locales::zh_hk::ChineseTraditionalHKTranslations;
 
 mod keys;
 mod locales;
@@ -19,8 +20,11 @@ static TRANSLATIONS: LazyLock<RwLock<HashMap<&'static str, LocaleTranslations>>>
             // 英文必须实现所有的翻译键
             m.insert("en-US", EnglishUSTranslations::get_translations());
 
-            // 其他语言可以只实现部分键
             m.insert("zh-CN", ChineseSimplifiedTranslations::get_translations());
+            m.insert(
+                "zh-HK",
+                ChineseTraditionalHKTranslations::get_translations(),
+            );
 
             m
         })
@@ -33,7 +37,7 @@ pub enum Language {
     // EnglishGB,
     ChineseSimplified,
     // ChineseTraditionalTW,
-    // ChineseTraditionalHK,
+    ChineseTraditionalHK,
 }
 
 impl FromStr for Language {
@@ -43,6 +47,7 @@ impl FromStr for Language {
         match s {
             "en-US" => Ok(Language::EnglishUS),
             "zh-CN" => Ok(Language::ChineseSimplified),
+            "zh-HK" => Ok(Language::ChineseTraditionalHK),
             _ => Err(format!("Unsupported language identifier: {}", s)),
         }
     }
@@ -55,7 +60,7 @@ impl Language {
             // LanguageVariant::EnglishGB => "en-GB",
             Language::ChineseSimplified => "zh-CN",
             // LanguageVariant::ChineseTraditionalTW => "zh-TW",
-            // LanguageVariant::ChineseTraditionalHK => "zh-HK",
+            Language::ChineseTraditionalHK => "zh-HK",
         }
     }
 
@@ -65,7 +70,7 @@ impl Language {
             // LanguageVariant::EnglishGB => "British English",
             Language::ChineseSimplified => "简体中文",
             // LanguageVariant::ChineseTraditionalTW => "繁體中文（台灣）",
-            // LanguageVariant::ChineseTraditionalHK => "繁體中文（香港）",
+            Language::ChineseTraditionalHK => "繁體中文（香港）",
         }
     }
 
@@ -101,7 +106,7 @@ thread_local! {
 }
 
 pub fn get_current_language() -> Language {
-    CURRENT_LANGUAGE.with(|lang| lang.borrow().clone())
+    CURRENT_LANGUAGE.with(|lang| *lang.borrow())
 }
 
 // pub fn set_language(language_id: &str) -> Result<(), String> {


### PR DESCRIPTION
This commit introduces support for the Traditional Chinese (Hong Kong) locale (`zh-HK`) by adding a new translation module `zh_hk.rs` and integrating it into the existing i18n system. Key changes include:

1. Added `zh_hk.rs` with translations for buttons, labels, tooltips, messages, titles, and placeholders.
2. Updated `mod.rs` to include the new `zh_hk` module and register the `zh-HK` locale in the `TRANSLATIONS` map.
3. Extended the `Language` enum to support `ChineseTraditionalHK` and updated related methods to handle the new locale.
4. Modified the `FromStr` implementation for `Language` to parse `zh-HK` identifiers.

The addition of this locale enhances the application's accessibility for users in Hong Kong by providing localized content in Traditional Chinese.