### PR TITLE
feat: Add `withArrow` prop to LazyTooltip components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,9 +112,10 @@ const App = () => {
                 positioning="after"
                 content={translate(
                   translations()!,
-                  "tooltip-new-version-available"
+                  "tooltip-new-version-available",
                 )}
                 relationship="label"
+                withArrow
               >
                 <LazyButton
                   appearance="transparent"
@@ -129,6 +130,7 @@ const App = () => {
               positioning="after"
               content={translate(translations()!, "tooltip-settings")}
               relationship="label"
+              withArrow
             >
               <LazyButton
                 appearance="transparent"

--- a/src/components/Settings/ThemesDirectory.tsx
+++ b/src/components/Settings/ThemesDirectory.tsx
@@ -52,6 +52,7 @@ const ThemesDirectory = () => {
         <LazyTooltip
           content={translate(translations()!, "tooltip-open-themes-directory")}
           relationship="label"
+          withArrow
         >
           <LazyButton
             appearance="transparent"

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -78,6 +78,7 @@ const Settings = () => {
             <LazyTooltip
               content={translate(translations()!, "tooltip-check-new-version")}
               relationship="label"
+              withArrow
             >
               <LazyButton
                 appearance="transparent"


### PR DESCRIPTION
This commit introduces the `withArrow` prop to all `LazyTooltip` components across the application. The prop ensures that tooltips display an arrow, improving the visual consistency and user experience. Changes were made in the following files:

- `src/App.tsx`
- `src/components/Settings/ThemesDirectory.tsx`
- `src/components/Settings/index.tsx`

The addition of `withArrow` enhances the tooltip's clarity and aligns with the design guidelines.