### PR TITLE
feat(i18n): Add error message for auto light/dark mode switch failure

### DIFF
--- a/src-tauri/src/i18n/keys.rs
+++ b/src-tauri/src/i18n/keys.rs
@@ -35,6 +35,8 @@ pub(super) const MESSAGE_NUMBER_TOO_LARGE: &str = "message-number-too-large";
 pub(super) const MESSAGE_NUMBER_TOO_SMALL: &str = "message-number-too-small";
 pub(super) const MESSAGE_SAVING_MANUAL_COORDINATES: &str = "message-saving-manual-coordinates";
 pub(super) const MESSAGE_STARTUP_FAILED: &str = "message-startup-failed";
+pub(super) const MESSAGE_SWITCH_AUTO_LIGHT_DARK_MODE_FAILED: &str =
+    "message-switch-auto-light-dark-mode-failed";
 pub(super) const MESSAGE_SWITCHING_TO_MANUAL_COORDINATE_CONFIG: &str =
     "message-switching-to-manual-coordinate-config";
 pub(super) const MESSAGE_THEMES_DIRECTORY_MOVED: &str = "message-themes-directory-moved";

--- a/src-tauri/src/i18n/locales/en_us.rs
+++ b/src-tauri/src/i18n/locales/en_us.rs
@@ -133,6 +133,13 @@ impl TranslationMap for EnglishUSTranslations {
             },
         );
         translations.insert(
+            MESSAGE_SWITCH_AUTO_LIGHT_DARK_MODE_FAILED,
+            TranslationValue::Template {
+                template: "Failed to switch auto light/dark mode: \n{{error}}",
+                params: &["error"],
+            },
+        );
+        translations.insert(
             MESSAGE_SWITCHING_TO_MANUAL_COORDINATE_CONFIG,
             TranslationValue::Template {
                 template: "Error occurred while switching to manual configuration of coordinates: \n{{error}}",

--- a/src-tauri/src/i18n/locales/zh_cn.rs
+++ b/src-tauri/src/i18n/locales/zh_cn.rs
@@ -118,6 +118,13 @@ impl TranslationMap for ChineseSimplifiedTranslations {
             },
         );
         translations.insert(
+            MESSAGE_SWITCH_AUTO_LIGHT_DARK_MODE_FAILED,
+            TranslationValue::Template {
+                template: "切换自动切换明暗模式失败: \n{{error}}",
+                params: &["error"],
+            },
+        );
+        translations.insert(
             MESSAGE_SWITCHING_TO_MANUAL_COORDINATE_CONFIG,
             TranslationValue::Template {
                 template: "切换至手动配置坐标时出错：\n{{error}}",

--- a/src/components/Settings/AutoDetectColorMode.tsx
+++ b/src/components/Settings/AutoDetectColorMode.tsx
@@ -2,18 +2,29 @@ import { LazySwitch } from "~/lazy";
 import SettingsItem from "./item";
 import { useAppContext } from "~/context";
 import { writeConfigFile } from "~/commands";
-import { translate } from "~/utils/i18n";
+import { translate, translateErrorMessage } from "~/utils/i18n";
+import { message } from "@tauri-apps/plugin-dialog";
 
 const AutoDetectColorMode = () => {
   const { config, refetchConfig, translations } = useAppContext();
 
   const onSwitchAutoDetectColorMode = async () => {
-    await writeConfigFile({
-      ...config()!,
-      auto_detect_color_mode: !config()!.auto_detect_color_mode,
-    });
-
-    refetchConfig();
+    try {
+      await writeConfigFile({
+        ...config()!,
+        auto_detect_color_mode: !config()!.auto_detect_color_mode,
+      });
+      refetchConfig();
+    } catch (error) {
+      message(
+        translateErrorMessage(
+          translations()!,
+          "message-switch-auto-light-dark-mode-failed",
+          error,
+        ),
+        { kind: "error" },
+      );
+    }
   };
 
   return (

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -16,3 +16,12 @@ export const translate = (
   }
   return result;
 };
+
+export const translateErrorMessage = (
+  translations: Translations,
+  key: TranslationKey,
+  error: unknown,
+  params: Record<string, string> = {},
+) => {
+  return translate(translations, key, { ...params, error: String(error) });
+};

--- a/types/i18n.d.ts
+++ b/types/i18n.d.ts
@@ -26,6 +26,7 @@ type TranslationKey =
   | "message-number-too-large"
   | "message-saving-manual-coordinates"
   | "message-startup-failed"
+  | "message-switch-auto-light-dark-mode-failed"
   | "message-switching-to-manual-coordinate-config"
   | "message-themes-directory-moved"
   | "message-version-is-the-latest"


### PR DESCRIPTION
- Added `MESSAGE_SWITCH_AUTO_LIGHT_DARK_MODE_FAILED` key to `keys.rs` for handling auto light/dark mode switch failures.
- Included corresponding translations in both `en_us.rs` and `zh_cn.rs` locales.
- Enhanced `AutoDetectColorMode.tsx` to display an error message when switching auto light/dark mode fails.
- Introduced `translateErrorMessage` utility in `i18n.ts` to handle error message translations.
- Updated `i18n.d.ts` to include the new translation key.