### PR TITLE
refactor(logging): change error logging from debug to display format

### DIFF
--- a/daemon/src/color_mode.rs
+++ b/daemon/src/color_mode.rs
@@ -177,7 +177,7 @@ fn notify_theme_change() -> DwallResult<()> {
                 WPARAM(0),
                 LPARAM(theme_name.as_ptr() as isize),
             ) {
-                warn!(notification = notification, error = ?e, "Failed to broadcast notification");
+                warn!(notification = notification, error = %e, "Failed to broadcast notification");
             } else {
                 debug!(
                     notification = notification,

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -299,7 +299,7 @@ impl ConfigManager {
         let content = tokio::fs::read_to_string(&self.config_path).await?;
 
         let config: Config = toml::from_str(&content).map_err(|e| {
-            error!(error = ?e, "Failed to parse configuration");
+            error!(error = %e, "Failed to parse configuration");
             ConfigError::Deserialization(e)
         })?;
 
@@ -337,7 +337,7 @@ impl ConfigManager {
     /// Writes the configuration to the file
     async fn write_config_to_file(&self, config: &Config) -> DwallResult<()> {
         let toml_string = toml::to_string(config).map_err(|e| {
-            error!(error = ?e, "Failed to serialize configuration");
+            error!(error = %e, "Failed to serialize configuration");
             ConfigError::Serialization(e)
         })?;
 

--- a/daemon/src/lazy.rs
+++ b/daemon/src/lazy.rs
@@ -7,7 +7,7 @@ pub static DWALL_CONFIG_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
 
     if !app_config_dir.exists() {
         if let Err(e) = fs::create_dir(&app_config_dir) {
-            error!(error = ?e, "Failed to create config directory");
+            error!(error = %e, "Failed to create config directory");
             panic!("Failed to create config directory: {}", e);
         } else {
             info!(path = %app_config_dir.display(), "Config directory created successfully");
@@ -27,7 +27,7 @@ pub static DWALL_CACHE_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
 
     if !dir.exists() {
         if let Err(e) = fs::create_dir(&dir) {
-            error!(error = ?e, "Failed to create cache directory");
+            error!(error = %e, "Failed to create cache directory");
             panic!("Failed to create cache directory: {}", e);
         } else {
             info!("Cache directory created successfully at: {}", dir.display());

--- a/daemon/src/monitor/mod.rs
+++ b/daemon/src/monitor/mod.rs
@@ -69,7 +69,7 @@ impl MonitorManager {
                 }
                 _ => {
                     error!(
-                        error = ?error,
+                        error = %error,
                         "Failed to set wallpaper for monitor"
                     );
                     return Err(error.into());
@@ -104,7 +104,7 @@ impl MonitorManager {
             .await
             .map_err(|e| {
                 error!(
-                    error = ?e,
+                    error = %e,
                     monitor_id = monitor_id,
                     wallpaper_path = %wallpaper_path.display(),
                     "Failed to set wallpaper for monitor after refresh"

--- a/daemon/src/monitor/monitor_info.rs
+++ b/daemon/src/monitor/monitor_info.rs
@@ -164,7 +164,7 @@ pub(crate) fn fetch_system_monitors() -> DwallResult<HashMap<String, DisplayMoni
         ) {
             Ok(name) => name,
             Err(e) => {
-                warn!(error = ?e, "Failed to get friendly name, using fallback");
+                warn!(error = %e, "Failed to get friendly name, using fallback");
                 format!("Display {}", index + 1) // Fallback name
             }
         };

--- a/daemon/src/monitor/wallpaper_manager.rs
+++ b/daemon/src/monitor/wallpaper_manager.rs
@@ -47,7 +47,7 @@ impl WallpaperManager {
         let desktop_wallpaper: IDesktopWallpaper = unsafe {
             CoCreateInstance(&DesktopWallpaper as *const _, None, CLSCTX_ALL).map_err(|e| {
                 error!(
-                    error = ?e,
+                    error = %e,
                     "Failed to create desktop wallpaper COM instance"
                 );
                 WallpaperError::Instance(e)
@@ -124,7 +124,7 @@ impl WallpaperManager {
                 .SetWallpaper(&device_path, &wallpaper_path)
                 .map_err(|e| {
                     error!(
-                        error = ?e,
+                        error = %e,
                         monitor_id = monitor.device_path(),
                         wallpaper_path = %wallpaper_path,
                         "Failed to set wallpaper for monitor"

--- a/daemon/src/position/geolocation_access.rs
+++ b/daemon/src/position/geolocation_access.rs
@@ -23,7 +23,7 @@ pub async fn check_location_permission() -> DwallResult<()> {
     .await?
     .get()
     .map_err(|e| {
-        error!(error = ?e, "Failed to get access status");
+        error!(error = %e, "Failed to get access status");
         DwallError::Windows(e)
     })?;
 

--- a/daemon/src/position/position_manager.rs
+++ b/daemon/src/position/position_manager.rs
@@ -39,7 +39,7 @@ async fn get_geo_position() -> DwallResult<Position> {
     .await?
     .get()
     .map_err(|e| {
-        error!(error = ?e, "Failed to retrieve geoposition");
+        error!(error = %e, "Failed to retrieve geoposition");
         DwallError::Windows(e)
     })?;
 

--- a/daemon/src/position/windows_api_helper.rs
+++ b/daemon/src/position/windows_api_helper.rs
@@ -16,7 +16,7 @@ where
             Ok(result)
         }
         Err(e) => {
-            error!(error = ?e, "{} failed", operation);
+            error!(error = %e, "{} failed", operation);
             Err(DwallError::Windows(e))
         }
     }

--- a/daemon/src/theme/manager.rs
+++ b/daemon/src/theme/manager.rs
@@ -34,7 +34,7 @@ impl WallpaperManager {
 
     fn get_current_lock_screen_image() -> DwallResult<Uri> {
         let result = LockScreen::OriginalImageFile().map_err(|e| {
-            error!(error = ?e, "Failed to retrieve lock screen image");
+            error!(error = %e, "Failed to retrieve lock screen image");
             e
         })?;
 
@@ -47,7 +47,7 @@ impl WallpaperManager {
         let uri = Uri::CreateUri(&image_path_hstring).map_err(|e| {
             error!(
                 path = %image_path.display(),
-                error = ?e,
+                error = %e,
                 "Failed to create URI for lock screen image",
             );
             e
@@ -64,7 +64,7 @@ impl WallpaperManager {
         let file = StorageFile::GetFileFromPathAsync(&image_path_hstring).map_err(|e| {
             error!(
                 path = %image_path.display(),
-                error = ?e,
+                error = %e,
                 "Failed to get storage file for lock screen",
             );
             e
@@ -72,7 +72,7 @@ impl WallpaperManager {
         let file = file.get().map_err(|e| {
             error!(
                 path = %image_path.display(),
-                error = ?e,
+                error = %e,
                 "Failed to retrieve async storage file",
             );
             e
@@ -81,7 +81,7 @@ impl WallpaperManager {
         let i_storage_file: IStorageFile = file.cast().map_err(|e| {
             error!(
                 path = %image_path.display(),
-                error = ?e,
+                error = %e,
                 "Failed to cast storage file",
             );
             e
@@ -89,7 +89,7 @@ impl WallpaperManager {
         let result = LockScreen::SetImageFileAsync(&i_storage_file).map_err(|e| {
             error!(
                 path = %image_path.display(),
-                error = ?e,
+                error = %e,
                 "Failed to set lock screen image async",
             );
             e
@@ -97,7 +97,7 @@ impl WallpaperManager {
         result.get().map_err(|e| {
             error!(
                 path = %image_path.display(),
-                error = ?e,
+                error = %e,
                 "Failed to complete lock screen image setting",
             );
             e

--- a/daemon/src/theme/processor.rs
+++ b/daemon/src/theme/processor.rs
@@ -67,7 +67,7 @@ impl ThemeProcessor {
                 Err(e) => {
                     consecutive_failures += 1;
                     error!(
-                        error = ?e,
+                        error = %e,
                         consecutive_failures,
                         max_failures = MAX_CONSECUTIVE_FAILURES,
                         "Failed to process theme cycle"
@@ -263,7 +263,7 @@ async fn set_lock_screen_wallpaper(
         }
         Err(e) => {
             warn!(
-                error = ?e,
+                error = %e,
                 theme_id = theme_id,
                 "Failed to find matching wallpaper for lock screen"
             );
@@ -326,7 +326,7 @@ async fn process_theme_cycle(
         .await
         {
             error!(
-                error = ?e,
+                error = %e,
                 monitor_id = monitor_id,
                 theme_id = monitor_theme_id,
                 "Failed to process wallpaper for monitor"
@@ -342,7 +342,7 @@ async fn process_theme_cycle(
         if let Some(theme_id) = lock_screen_wallpaper {
             if let Err(e) = set_lock_screen_wallpaper(config, &theme_id, &sun_position).await {
                 warn!(
-                    error = ?e,
+                    error = %e,
                     "Failed to set lock screen wallpaper, continuing with other operations"
                 );
                 // Continue execution even if lock screen wallpaper setting fails
@@ -359,7 +359,7 @@ async fn process_theme_cycle(
         );
         if let Err(e) = set_color_mode(color_mode) {
             warn!(
-                error = ?e,
+                error = %e,
                 "Failed to set system color mode, continuing with other operations"
             );
             // Continue execution even if color mode setting fails

--- a/daemon/src/theme/validator.rs
+++ b/daemon/src/theme/validator.rs
@@ -40,13 +40,13 @@ impl ThemeValidator {
         }
 
         let solar_config_content = fs::read_to_string(&solar_config_path).await.map_err(|e| {
-            error!(error = ?e, "Failed to read solar configuration");
+            error!(error = %e, "Failed to read solar configuration");
             e
         })?;
 
         let solar_angles: Vec<SolarAngle> =
             serde_json::from_str(&solar_config_content).map_err(|e| {
-                error!(error = ?e, "Failed to parse solar configuration JSON");
+                error!(error = %e, "Failed to parse solar configuration JSON");
                 e
             })?;
 

--- a/src-tauri/src/cache/cache_manager.rs
+++ b/src-tauri/src/cache/cache_manager.rs
@@ -65,7 +65,7 @@ impl ThumbnailCache {
                     }
                     Err(e) => {
                         error!(
-                            error = ?e,
+                            error = %e,
                             "Failed to clean up expired cache during initialization"
                         );
                     }
@@ -123,7 +123,7 @@ impl ThumbnailCache {
                 if let Err(e) = FsService::update_file_access_time(&metadata.path) {
                     warn!(
                         path = %metadata.path.display(),
-                        error = ?e,
+                        error = %e,
                         "Failed to update file access time"
                     );
                 }
@@ -144,11 +144,11 @@ impl ThumbnailCache {
                 // 5% chance to trigger cleanup
                 tokio::spawn(async {
                     if let Err(e) = CleanupService::cleanup_expired_cache().await {
-                        error!(error = ?e, "Failed to clean up expired cache");
+                        error!(error = %e, "Failed to clean up expired cache");
                     }
 
                     if let Err(e) = CleanupService::enforce_cache_size_limit().await {
-                        error!(error = ?e, "Failed to enforce cache size limit");
+                        error!(error = %e, "Failed to enforce cache size limit");
                     }
                 });
             }
@@ -177,7 +177,7 @@ impl ThumbnailCache {
                 let metadata = tokio::fs::metadata(&image_path).await.map_err(|e| {
                     error!(
                         path = %image_path.display(),
-                        error = ?e,
+                        error = %e,
                         "Failed to get file metadata"
                     );
                     CacheError::from(e)

--- a/src-tauri/src/cache/cleanup_service.rs
+++ b/src-tauri/src/cache/cleanup_service.rs
@@ -34,7 +34,7 @@ impl CleanupService {
         let mut entries = fs::read_dir(&thumbnails_dir).await.map_err(|e| {
             error!(
                 dir = %thumbnails_dir.display(),
-                error = ?e,
+                error = %e,
                 "Failed to read thumbnails directory"
             );
             e
@@ -50,7 +50,7 @@ impl CleanupService {
                     Err(e) => {
                         error!(
                             dir = %path.display(),
-                            error = ?e,
+                            error = %e,
                             "Failed to read theme directory"
                         );
                         continue;
@@ -73,7 +73,7 @@ impl CleanupService {
                                     if let Err(e) = fs::remove_file(&file_path).await {
                                         error!(
                                             file = %file_path.display(),
-                                            error = ?e,
+                                            error = %e,
                                             "Failed to remove expired cache file"
                                         );
                                     } else {
@@ -95,7 +95,7 @@ impl CleanupService {
                     if let Err(e) = fs::remove_dir(&path).await {
                         error!(
                             dir = %path.display(),
-                            error = ?e,
+                            error = %e,
                             "Failed to remove empty theme directory"
                         );
                     } else {
@@ -131,7 +131,7 @@ impl CleanupService {
         let mut entries = fs::read_dir(&thumbnails_dir).await.map_err(|e| {
             error!(
                 dir = %thumbnails_dir.display(),
-                error = ?e,
+                error = %e,
                 "Failed to read thumbnails directory"
             );
             e
@@ -146,7 +146,7 @@ impl CleanupService {
                     Err(e) => {
                         error!(
                             dir = %path.display(),
-                            error = ?e,
+                            error = %e,
                             "Failed to read theme directory"
                         );
                         continue;
@@ -183,7 +183,7 @@ impl CleanupService {
             if let Err(e) = fs::remove_file(&file_path).await {
                 error!(
                     file = %file_path.display(),
-                    error = ?e,
+                    error = %e,
                     "Failed to remove cache file during size enforcement"
                 );
             } else {
@@ -207,7 +207,7 @@ impl CleanupService {
         let mut entries = fs::read_dir(dir).await.map_err(|e| {
             error!(
                 dir = %dir.display(),
-                error = ?e,
+                error = %e,
                 "Failed to read directory"
             );
             e
@@ -223,7 +223,7 @@ impl CleanupService {
                     if let Err(e) = fs::remove_dir(&path).await {
                         error!(
                             dir = %path.display(),
-                            error = ?e,
+                            error = %e,
                             "Failed to remove empty directory"
                         );
                     } else {

--- a/src-tauri/src/cache/fs_service.rs
+++ b/src-tauri/src/cache/fs_service.rs
@@ -41,7 +41,7 @@ impl FsService {
         let mut entries = fs::read_dir(dir).await.map_err(|e| {
             error!(
                 dir = %dir.display(),
-                error = ?e,
+                error = %e,
                 "Failed to read directory"
             );
             e

--- a/src-tauri/src/cache/http_service.rs
+++ b/src-tauri/src/cache/http_service.rs
@@ -61,13 +61,13 @@ impl HttpService {
 
             let result = async {
                 let client = Self::create_http_client().await.map_err(|e| {
-                    error!(error = ?e, "Failed to create HTTP client");
+                    error!(error = %e, "Failed to create HTTP client");
                     CacheError::from(e)
                 })?;
 
                 trace!(url = url, "Sending HTTP GET request");
                 let response = client.get(url).send().await.map_err(|e| {
-                    error!(url = url, error = ?e, "Failed to get online image");
+                    error!(url = url, error = %e, "Failed to get online image");
                     CacheError::from(e)
                 })?;
 
@@ -89,7 +89,7 @@ impl HttpService {
                 trace!(url = url, length = ?content_length, "Received response. Reading bytes");
 
                 let buffer = response.bytes().await.map_err(|e| {
-                    error!(error = ?e, "Failed to read image bytes from response");
+                    error!(error = %e, "Failed to read image bytes from response");
                     CacheError::from(e)
                 })?;
 
@@ -102,7 +102,7 @@ impl HttpService {
                 fs::write(&temp_path, &buffer).map_err(|e| {
                     error!(
                         temp_path = %temp_path.display(),
-                        error = ?e,
+                        error = %e,
                         "Failed to write temporary image"
                     );
                     CacheError::from(e)
@@ -117,7 +117,7 @@ impl HttpService {
                     error!(
                         from = %temp_path.display(),
                         to = %image_path.display(),
-                        error = ?e,
+                        error = %e,
                         "Failed to rename temporary file"
                     );
                     CacheError::from(e)
@@ -141,7 +141,7 @@ impl HttpService {
             if let Err(e) = fs::remove_file(&temp_path) {
                 error!(
                     temp_path = %temp_path.display(),
-                    error = ?e,
+                    error = %e,
                     "Failed to remove temporary file after error"
                 );
             }

--- a/src-tauri/src/download/extractor.rs
+++ b/src-tauri/src/download/extractor.rs
@@ -25,7 +25,7 @@ impl ThemeExtractor {
             error!(
                 theme_id = theme_id,
                 zip_path = %zip_path.display(),
-                error = ?e,
+                error = %e,
                 "Failed to read theme archive"
             );
             e
@@ -37,7 +37,7 @@ impl ThemeExtractor {
                 theme_id = theme_id,
                 target_dir = %target_dir.display(),
                 zip_path = %zip_path.display(),
-                error = ?e,
+                error = %e,
                 "Failed to extract theme archive"
             );
             e
@@ -54,7 +54,7 @@ impl ThemeExtractor {
             error!(
                 theme_id = theme_id,
                 zip_path = %zip_path.display(),
-                error = ?e,
+                error = %e,
                 "Failed to delete theme archive"
             );
             e

--- a/src-tauri/src/download/file_manager.rs
+++ b/src-tauri/src/download/file_manager.rs
@@ -34,7 +34,7 @@ impl ThemeFileManager {
             fs::remove_dir_all(target_dir).await.map_err(|e| {
                 error!(
                     dir_path = %target_dir.display(),
-                    error = ?e,
+                    error = %e,
                     "Failed to remove existing theme directory"
                 );
                 e
@@ -46,7 +46,7 @@ impl ThemeFileManager {
         fs::create_dir_all(target_dir).await.map_err(|e| {
             error!(
                 dir_path = %target_dir.display(),
-                error = ?e,
+                error = %e,
                 "Failed to create theme directory"
             );
             e
@@ -75,7 +75,7 @@ impl ThemeFileManager {
             if let Err(e) = fs::remove_file(temp_file_path).await {
                 error!(
                     file_path = %temp_file_path.display(),
-                    error = ?e,
+                    error = %e,
                     "Failed to remove temporary file"
                 );
             } else {
@@ -95,7 +95,7 @@ impl ThemeFileManager {
                 error!(
                     from = %temp_file_path.display(),
                     to = %final_file_path.display(),
-                    error = ?e,
+                    error = %e,
                     "Failed to rename temporary file to final file"
                 );
                 e.into()

--- a/src-tauri/src/download/http_service.rs
+++ b/src-tauri/src/download/http_service.rs
@@ -41,7 +41,7 @@ impl HttpDownloadService {
             .connect_timeout(Duration::from_secs(120))
             .build()
             .map_err(|e| {
-                error!(error = ?e, "Failed to create HTTP client");
+                error!(error = %e, "Failed to create HTTP client");
                 e
             })
             .unwrap();
@@ -119,7 +119,7 @@ impl HttpDownloadService {
                 error!(
                     theme_id = theme_id,
                     file_path = %file_path.display(),
-                    error = ?e,
+                    error = %e,
                     "Failed to get metadata of existing temp file"
                 );
                 e
@@ -141,7 +141,7 @@ impl HttpDownloadService {
                     error!(
                         theme_id = theme_id,
                         file_path = %file_path.display(),
-                        error = ?e,
+                        error = %e,
                         "Failed to open existing temp file"
                     );
                     e
@@ -152,7 +152,7 @@ impl HttpDownloadService {
                 error!(
                     theme_id = theme_id,
                     file_path = %file_path.display(),
-                    error = ?e,
+                    error = %e,
                     "Failed to create temp file"
                 );
                 e
@@ -190,7 +190,7 @@ impl HttpDownloadService {
             error!(
                 theme_id = theme_id,
                 url = %url,
-                error = ?err,
+                error = %err,
                 "Failed to establish connection for download"
             );
             err
@@ -219,7 +219,7 @@ impl HttpDownloadService {
                 return Err(DownloadError::NotFound(theme_id.to_string()).into());
             }
 
-            error!(theme_id = theme_id, error = ?e, "Got an error response");
+            error!(theme_id = theme_id, error = %e, "Got an error response");
             return Err(e.into());
         }
 
@@ -255,7 +255,7 @@ impl HttpDownloadService {
                 Err(e) => {
                     error!(
                         theme_id = context.theme_id,
-                        error = ?e,
+                        error = %e,
                         "Failed to download chunk"
                     );
                     return Err(e.into());
@@ -267,7 +267,7 @@ impl HttpDownloadService {
                     theme_id = context.theme_id,
                     downloaded_bytes = *context.downloaded_bytes,
                     total_bytes = context.total_size,
-                    error = ?e,
+                    error = %e,
                     "Failed to write chunk to file"
                 );
                 return Err(e.into());
@@ -309,7 +309,7 @@ impl HttpDownloadService {
                     theme_id = theme_id,
                     downloaded_bytes,
                     total_bytes,
-                    error = ?e,
+                    error = %e,
                     "Failed to emit download progress"
                 );
                 e

--- a/src-tauri/src/fs.rs
+++ b/src-tauri/src/fs.rs
@@ -9,17 +9,17 @@ async fn copy_dir(src: &Path, dest: &Path) -> std::io::Result<()> {
     create_dir_if_missing(&dest).await?;
 
     let mut dir = fs::read_dir(src).await.map_err(|e| {
-        error!(path = %src.display(), error = ?e, "Failed to read source directory");
+        error!(path = %src.display(), error = %e, "Failed to read source directory");
         e
     })?;
 
     while let Some(entry) = dir.next_entry().await.map_err(|e| {
-        error!(path = %src.display(), error = ?e, "Failed to get next entry in source directory");
+        error!(path = %src.display(), error = %e, "Failed to get next entry in source directory");
         e
     })? {
         let src_path = entry.path();
         let file_type = entry.file_type().await.map_err(|e| {
-            error!(path = %src_path.display(), error = ?e, "Failed to get file type of entry");
+            error!(path = %src_path.display(), error = %e, "Failed to get file type of entry");
             e
         })?;
         let dest_path = dest.join(src_path.strip_prefix(src).unwrap());
@@ -30,7 +30,7 @@ async fn copy_dir(src: &Path, dest: &Path) -> std::io::Result<()> {
         } else {
             info!(src = %src_path.display(), dest = %dest_path.display(), "Copying file");
             fs::copy(&src_path, &dest_path).await.map_err(|e| {
-                error!(src = %src_path.display(), dest = %dest_path.display(), error = ?e, "Failed to copy file");
+                error!(src = %src_path.display(), dest = %dest_path.display(), error = %e, "Failed to copy file");
                 e
             })?;
         }
@@ -75,7 +75,7 @@ pub async fn move_themes_directory(config: Config, dir_path: PathBuf) -> DwallSe
     match prepare_new_config(&config, &dir_path).await {
         Ok(_) => {}
         Err(e) => {
-            error!(error = ?e, "Failed to prepare new configuration");
+            error!(error = %e, "Failed to prepare new configuration");
             return Err(e);
         }
     };
@@ -162,7 +162,7 @@ async fn perform_themes_directory_move(
         .map_err(ThemeDirectoryMoveError::CopyFailed)?;
 
     fs::remove_dir_all(&source).await.map_err(|e| {
-        error!(source = %source.display(), error = ?e, "Failed to remove old themes directory");
+        error!(source = %source.display(), error = %e, "Failed to remove old themes directory");
         ThemeDirectoryMoveError::RemoveFailed(e)
     })?;
 
@@ -182,7 +182,7 @@ pub async fn create_dir_if_missing<P: AsRef<Path>>(path: P) -> std::io::Result<(
                 info!(path = %path.display(), "Successfully created directory");
             })
             .map_err(|e| {
-                error!(path = %path.display(), error = ?e, "Failed to create directory");
+                error!(path = %path.display(), error = %e, "Failed to create directory");
                 e
             })
     } else {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -48,11 +48,11 @@ fn show_window(app: AppHandle, label: &str) -> DwallSettingsResult<()> {
     if let Some(window) = app.get_webview_window(label) {
         trace!(label = label, "Window found for label");
         window.show().map_err(|e| {
-            error!(error = ?e, "Failed to show window");
+            error!(error = %e, "Failed to show window");
             e
         })?;
         window.set_focus().map_err(|e| {
-            error!(error = ?e, "Failed to set window focus");
+            error!(error = %e, "Failed to set window focus");
             e
         })?;
     } else {
@@ -71,7 +71,7 @@ async fn read_config_file() -> DwallSettingsResult<Config> {
             Ok(config)
         }
         Err(e) => {
-            error!(error = ?e, "Failed to read configuration file");
+            error!(error = %e, "Failed to read configuration file");
             Err(e.into())
         }
     }
@@ -86,7 +86,7 @@ async fn write_config_file(config: Config) -> DwallSettingsResult<()> {
             Ok(())
         }
         Err(e) => {
-            error!(config = ?config, error = ?e, "Failed to write configuration file");
+            error!(config = ?config, error = %e, "Failed to write configuration file");
             Err(e.into())
         }
     }
@@ -95,7 +95,7 @@ async fn write_config_file(config: Config) -> DwallSettingsResult<()> {
 #[tauri::command]
 async fn open_dir(dir_path: Cow<'_, Path>) -> DwallSettingsResult<()> {
     open::that(dir_path.as_os_str()).map_err(|e| {
-        error!(error = ?e, "Failed to open app config directory");
+        error!(error = %e, "Failed to open app config directory");
         e.into()
     })
 }
@@ -103,7 +103,7 @@ async fn open_dir(dir_path: Cow<'_, Path>) -> DwallSettingsResult<()> {
 #[tauri::command]
 async fn open_config_dir() -> DwallSettingsResult<()> {
     open::that(DWALL_CONFIG_DIR.as_os_str()).map_err(|e| {
-        error!(error = ?e, "Failed to open app config directory");
+        error!(error = %e, "Failed to open app config directory");
         e.into()
     })
 }
@@ -147,12 +147,12 @@ async fn main() -> DwallSettingsResult<()> {
             if let Some(w) = app.get_webview_window("main") {
                 info!("Application instance already running, focusing existing window");
                 if let Err(e) = w.set_focus() {
-                    error!(error = ?e, "Failed to set focus on existing window");
+                    error!(error = %e, "Failed to set focus on existing window");
                 }
             } else {
                 match create_main_window(app) {
                     Ok(_) => debug!("New main window created"),
-                    Err(e) => error!(error = ?e, "Failed to create new main window"),
+                    Err(e) => error!(error = %e, "Failed to create new main window"),
                 }
             }
         }))
@@ -188,7 +188,7 @@ async fn main() -> DwallSettingsResult<()> {
                 trace!("Application exit event received");
                 match kill_daemon() {
                     Ok(_) => debug!("Daemon process killed on exit"),
-                    Err(e) => error!(error = ?e, "Failed to kill daemon process on exit"),
+                    Err(e) => error!(error = %e, "Failed to kill daemon process on exit"),
                 }
             }
         })

--- a/src-tauri/src/process_manager.rs
+++ b/src-tauri/src/process_manager.rs
@@ -160,7 +160,7 @@ pub fn find_daemon_process() -> DwallSettingsResult<Option<u32>> {
 
     // Create process snapshot
     let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) }.map_err(|e| {
-        error!(error = ?e, "Failed to create process snapshot");
+        error!(error = %e, "Failed to create process snapshot");
         ProcessManagerError::SnapshotCreationFailed(e)
     })?;
 
@@ -224,7 +224,7 @@ fn check_process_path(pid: u32, expected_path: &str) -> DwallSettingsResult<Opti
     // Try to get the full path of the executable
     let process_handle = unsafe {
         OpenProcess(PROCESS_QUERY_INFORMATION, false, pid).map_err(|e| {
-            trace!(pid = pid, error = ?e, "Could not open process");
+            trace!(pid = pid, error = %e, "Could not open process");
             ProcessManagerError::ProcessOpenFailed(e)
         })
     };
@@ -310,7 +310,7 @@ pub fn kill_daemon() -> DwallSettingsResult<()> {
             // Open process with termination rights
             let process_handle = unsafe {
                 OpenProcess(PROCESS_TERMINATE, false, pid).map_err(|e| {
-                    error!(error = ?e, pid = pid, "Failed to open process for termination");
+                    error!(error = %e, pid, "Failed to open process for termination");
                     ProcessManagerError::ProcessTerminationFailed { pid, error: e }
                 })
             }?;
@@ -320,12 +320,12 @@ pub fn kill_daemon() -> DwallSettingsResult<()> {
             // Terminate the process
             unsafe {
                 TerminateProcess(process_handle.as_raw(), 0).map_err(|e| {
-                    error!(error = ?e, pid = pid, "Failed to terminate daemon process");
+                    error!(error = %e, pid, "Failed to terminate daemon process");
                     ProcessManagerError::ProcessTerminationFailed { pid, error: e }
                 })
             }?;
 
-            info!(pid = pid, "Successfully terminated daemon process with PID");
+            info!(pid, "Successfully terminated daemon process with PID");
             Ok(())
         }
         None => {

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -64,7 +64,7 @@ fn setup_updater(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
     app.handle()
         .plugin(tauri_plugin_updater::Builder::new().build())
         .map_err(|e| {
-            error!(error = ?e, "Failed to initialize update plugin");
+            error!(error = %e, "Failed to initialize update plugin");
             e
         })?;
 

--- a/src-tauri/src/theme.rs
+++ b/src-tauri/src/theme.rs
@@ -40,7 +40,7 @@ pub fn get_last_daemon_error() -> Option<String> {
     let file = match File::open(&log_file_path) {
         Ok(file) => file,
         Err(e) => {
-            warn!(error = ?e, "Failed to open daemon log file");
+            warn!(error = %e, "Failed to open daemon log file");
             return None;
         }
     };
@@ -110,7 +110,7 @@ pub fn launch_daemon() -> DwallSettingsResult<()> {
             Ok(())
         }
         Err(e) => {
-            error!(error = ?e, path = ?daemon_path, "Failed to start daemon process");
+            error!(error = %e, path = ?daemon_path, "Failed to start daemon process");
             Err(e.into())
         }
     }

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -85,7 +85,7 @@ pub fn set_window_color_mode(
             Ok(())
         }
         Err(error) => {
-            error!(mode = ?color_mode, error = ?error, "Failed to set window color mode");
+            error!(mode = ?color_mode, error = %error, "Failed to set window color mode");
             Err(error)
         }
     }
@@ -149,7 +149,7 @@ fn set_legacy_dark_mode(window_handle: HWND, color_mode: &ColorMode) -> DwallSet
             std::mem::size_of::<u32>() as u32,
         )
         .map_err(|e| {
-            error!(error = ?e, "Failed to set legacy dark mode");
+            error!(error = %e, "Failed to set legacy dark mode");
             e.into()
         })
     }


### PR DESCRIPTION
Standardize error logging across the codebase by using the display format (%e) instead of debug format (?e) for errors. This makes error messages more readable in logs while still providing all necessary information.