### PR TITLE
ci: add checkout step before deleting nightly release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -128,6 +128,8 @@ jobs:
     needs: check-nightly-conditions
     if: needs.check-nightly-conditions.outputs.should_build == 'true' && needs.check-nightly-conditions.outputs.has_nightly == 'true'
     steps:
+      - uses: actions/checkout@v4
+
       - name: Delete existing nightly release and tag
         run: |
           echo "Deleting existing nightly release and tag..."


### PR DESCRIPTION
The checkout step was missing before attempting to delete the nightly release, which could cause the workflow to fail. Adding it ensures the workflow has access to the repository contents.