### PR TITLE
perf: optimize release profile for better incremental build and size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,6 @@ windows = { version = "0.61", default-features = false }
 panic = "abort"
 codegen-units = 1
 lto = true
-incremental = false
-opt-level = "s"     # Optimize for size
+incremental = true
+opt-level = "z"
 strip = true
-
-# New profile for memory-optimized builds
-[profile.memory-opt]
-inherits = "release"
-opt-level = "z"      # Aggressive size optimization
-lto = "fat"          # Full LTO for maximum optimization
-panic = "abort"      # Reduce binary size
-strip = "symbols"    # Strip all symbols


### PR DESCRIPTION
- Enable incremental compilation in release build
- Change optimization level from "s" to "z" for better size reduction
- Remove custom memory-optimized profile to simplify build configuration
- Retain full link time optimization and symbol stripping for smaller binaries