### PR TITLE
refactor: restrict module and function visibility to crate scope

### DIFF
--- a/daemon/src/domain/time/mod.rs
+++ b/daemon/src/domain/time/mod.rs
@@ -1,1 +1,1 @@
-pub mod solar_calculator;
+pub(crate) mod solar_calculator;

--- a/daemon/src/domain/time/solar_calculator.rs
+++ b/daemon/src/domain/time/solar_calculator.rs
@@ -6,39 +6,39 @@ use time::OffsetDateTime;
 /// Astronomical calculation constants
 mod constants {
     /// Julian date for January 1, 2000 at 12:00 (TT)
-    pub const EPOCH_J2000: f64 = 2451545.0;
+    pub(crate) const EPOCH_J2000: f64 = 2451545.0;
 
     /// Number of days in a Julian century
-    pub const JULIAN_CENTURY_DAYS: f64 = 36525.0;
+    pub(crate) const JULIAN_CENTURY_DAYS: f64 = 36525.0;
 
     /// Earth's rotation rate in degrees per hour
-    pub const EARTH_ROTATION_RATE: f64 = 15.0;
+    pub(crate) const EARTH_ROTATION_RATE: f64 = 15.0;
 
     /// Hours per day
-    pub const HOURS_PER_DAY: f64 = 24.0;
+    pub(crate) const HOURS_PER_DAY: f64 = 24.0;
 
     /// Minutes per hour
-    pub const MINUTES_PER_HOUR: f64 = 60.0;
+    pub(crate) const MINUTES_PER_HOUR: f64 = 60.0;
 
     /// Seconds per hour
-    pub const SECONDS_PER_HOUR: f64 = 3600.0;
+    pub(crate) const SECONDS_PER_HOUR: f64 = 3600.0;
 
     /// Maximum atmospheric refraction correction at horizon (degrees)
-    pub const ATMOSPHERIC_REFRACTION_MAX: f64 = 0.55;
+    pub(crate) const ATMOSPHERIC_REFRACTION_MAX: f64 = 0.55;
 
     /// Polar region latitude threshold (degrees)
-    pub const POLAR_REGION_THRESHOLD: f64 = 89.9;
+    pub(crate) const POLAR_REGION_THRESHOLD: f64 = 89.9;
 }
 
 /// Solar angle data structure for wallpaper selection
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub(crate) struct SolarAngle {
     /// Image index for wallpaper selection
-    pub index: u8,
+    pub(crate) index: u8,
     /// Sun's altitude angle (degrees)
-    pub altitude: f64,
+    pub(crate) altitude: f64,
     /// Sun's azimuth angle (degrees)
-    pub azimuth: f64,
+    pub(crate) azimuth: f64,
 }
 
 /// Solar position calculator for astronomical computations

--- a/daemon/src/domain/visual/color_scheme.rs
+++ b/daemon/src/domain/visual/color_scheme.rs
@@ -46,7 +46,7 @@ impl fmt::Display for ColorMode {
 }
 
 /// Color scheme manager for Windows system theme management
-pub struct ColorSchemeManager;
+pub(crate) struct ColorSchemeManager;
 
 impl ColorSchemeManager {
     const PERSONALIZE_KEY_PATH: &str =
@@ -55,7 +55,7 @@ impl ColorSchemeManager {
     const SYSTEM_THEME_VALUE: &str = "SystemUsesLightTheme";
 
     /// Retrieve the current system color mode from registry
-    pub fn get_current_mode() -> DwallResult<ColorMode> {
+    pub(crate) fn get_current_mode() -> DwallResult<ColorMode> {
         info!("Retrieving current system color mode");
         let registry_key = RegistryKey::open(Self::PERSONALIZE_KEY_PATH, KEY_QUERY_VALUE)?;
 
@@ -83,7 +83,7 @@ impl ColorSchemeManager {
     }
 
     /// Set the system color mode in the registry
-    pub fn set_color_mode(mode: ColorMode) -> DwallResult<()> {
+    pub(crate) fn set_color_mode(mode: ColorMode) -> DwallResult<()> {
         info!(mode = %mode, "Setting system color mode");
         let registry_key = RegistryKey::open(Self::PERSONALIZE_KEY_PATH, KEY_SET_VALUE)?;
 
@@ -118,7 +118,7 @@ impl ColorSchemeManager {
 /// # Returns
 /// - `ColorMode::Light` if the sun is above the horizon or in twilight
 /// - `ColorMode::Dark` if the sun is below the twilight threshold
-pub fn determine_color_mode(altitude: f64) -> ColorMode {
+pub(crate) fn determine_color_mode(altitude: f64) -> ColorMode {
     trace!(altitude = altitude, "Determining color mode");
 
     if altitude > DAY_ALTITUDE_THRESHOLD {
@@ -137,7 +137,7 @@ pub fn determine_color_mode(altitude: f64) -> ColorMode {
 }
 
 /// Set the system color mode, checking first if it needs to be changed
-pub fn set_color_mode(color_mode: ColorMode) -> DwallResult<()> {
+pub(crate) fn set_color_mode(color_mode: ColorMode) -> DwallResult<()> {
     let current_color_mode = ColorSchemeManager::get_current_mode()?;
     if current_color_mode == color_mode {
         info!(mode = %color_mode, "Color mode is already set");

--- a/daemon/src/domain/visual/mod.rs
+++ b/daemon/src/domain/visual/mod.rs
@@ -1,8 +1,7 @@
 pub mod color_scheme;
 pub mod theme_processor;
-pub mod wallpaper;
+pub(crate) mod wallpaper;
 
 // Re-export commonly used types
-pub use color_scheme::{determine_color_mode, set_color_mode, ColorMode, ColorSchemeManager};
+pub use color_scheme::ColorMode;
 pub use theme_processor::{apply_solar_theme, SolarThemeValidator, ThemeProcessingError};
-pub use wallpaper::WallpaperSelector;

--- a/daemon/src/infrastructure/filesystem/config_manager.rs
+++ b/daemon/src/infrastructure/filesystem/config_manager.rs
@@ -9,27 +9,27 @@ use crate::{
 };
 
 /// Configuration manager for file operations
-pub struct ConfigManager {
+pub(crate) struct ConfigManager {
     config_path: PathBuf,
 }
 
 impl ConfigManager {
     /// Creates a new ConfigManager with the default config directory
-    pub async fn new() -> DwallResult<Self> {
+    pub(crate) async fn new() -> DwallResult<Self> {
         Ok(Self {
             config_path: DWALL_CONFIG_DIR.join("config.toml"),
         })
     }
 
     /// Creates a new ConfigManager with a specific config directory
-    pub fn with_config_dir(config_dir: &Path) -> Self {
+    pub(crate) fn with_config_dir(config_dir: &Path) -> Self {
         Self {
             config_path: config_dir.join("config.toml"),
         }
     }
 
     /// Reads the configuration from the file system
-    pub async fn read_config(&self) -> DwallResult<Config> {
+    pub(crate) async fn read_config(&self) -> DwallResult<Config> {
         if !self.config_path.exists() {
             warn!("Config file not found, using default configuration");
             return Ok(Config::default());
@@ -50,7 +50,7 @@ impl ConfigManager {
     }
 
     /// Writes the configuration to the file system
-    pub async fn write_config(&self, config: &Config) -> DwallResult<()> {
+    pub(crate) async fn write_config(&self, config: &Config) -> DwallResult<()> {
         config.validate()?;
 
         if !self.config_path.exists() {
@@ -67,7 +67,7 @@ impl ConfigManager {
         self.write_config_to_file(config).await
     }
 
-    async fn write_config_to_file(&self, config: &Config) -> DwallResult<()> {
+    pub(crate) async fn write_config_to_file(&self, config: &Config) -> DwallResult<()> {
         let toml_string = toml::to_string(config).map_err(|e| {
             error!(error = %e, "Failed to serialize configuration");
             ConfigError::Serialization(e)

--- a/daemon/src/infrastructure/filesystem/mod.rs
+++ b/daemon/src/infrastructure/filesystem/mod.rs
@@ -1,4 +1,4 @@
 pub mod config_manager;
 
 // Re-export commonly used types
-pub use config_manager::{read_config_file, write_config_file, ConfigManager};
+pub use config_manager::{read_config_file, write_config_file};

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -22,7 +22,7 @@ pub use domain::visual::{apply_solar_theme, SolarThemeValidator};
 
 // Re-export infrastructure types
 pub use infrastructure::display::{DisplayMonitor, DisplayMonitorProvider};
-pub use infrastructure::filesystem::{read_config_file, write_config_file, ConfigManager};
+pub use infrastructure::filesystem::{read_config_file, write_config_file};
 pub use infrastructure::platform::windows::{RegistryError, RegistryKey};
 
 // Backwards compatibility aliases


### PR DESCRIPTION
- Changed solar_calculator module to crate private in time domain
- Made astronomical constants and SolarAngle struct fields crate private
- Restricted ColorSchemeManager struct and its methods visibility to crate
- Limited functions in color_scheme and wallpaper modules to crate scope
- ConfigManager struct and all its associated methods set to crate private
- Removed public re-exports of ConfigManager and wallpaper module types
- Updated infrastructure and lib.rs exports to exclude restricted items