### PR TITLE
fix(config): apply defined constants for interval validation boundaries

### DIFF
--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -125,8 +125,8 @@ pub struct Config {
     /// Time interval for detecting solar altitude angle and azimuth angle
     /// Measured in seconds, range: [MIN_INTERVAL_SECONDS, MAX_INTERVAL_SECONDS]
     #[serde(default = "default_interval")]
-    #[validate(minimum = 1)]
-    #[validate(maximum = 600)]
+    #[validate(minimum = MIN_INTERVAL_SECONDS)]
+    #[validate(maximum = MAX_INTERVAL_SECONDS)]
     interval: u16,
 }
 


### PR DESCRIPTION
- Replace hardcoded minimum interval validation of 1 with MIN_INTERVAL_SECONDS constant
- Replace hardcoded maximum interval validation of 600 with MAX_INTERVAL_SECONDS constant
- Ensure interval validation uses consistent and centralized boundary values