### PR TITLE
refactor(geography): rename Coordinate to Position and add altitude field

### DIFF
--- a/daemon/src/domain/geography/mod.rs
+++ b/daemon/src/domain/geography/mod.rs
@@ -1,6 +1,6 @@
-pub mod coordinates;
+pub mod position;
 pub mod provider;
 
 // Re-export commonly used types
-pub use coordinates::{Coordinate, CoordinateError, GeolocationAccessError};
+pub use position::{CoordinateError, GeolocationAccessError, Position};
 pub use provider::check_location_permission;

--- a/daemon/src/domain/geography/position.rs
+++ b/daemon/src/domain/geography/position.rs
@@ -2,27 +2,29 @@ use std::fmt;
 
 use crate::error::DwallResult;
 
-/// Geographic position with latitude and longitude coordinates
+/// Geographic position with latitude, longitude and altitude
 ///
 /// This struct is optimized for performance with Copy trait and
 /// uses repr(C) for predictable memory layout.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-pub struct Coordinate {
+pub struct Position {
     latitude: f64,
     longitude: f64,
+    altitude: f64,
 }
 
-impl Coordinate {
-    /// Creates a new Coordinate with the given latitude and longitude
+impl Position {
+    /// Creates a new Position with the given latitude, longitude and altitude
     ///
     /// # Arguments
     /// * `latitude` - The latitude in degrees, must be between -90 and 90
     /// * `longitude` - The longitude in degrees, must be between -180 and 180
+    /// * `altitude` - The altitude in meters, can be negative
     ///
     /// # Returns
-    /// A new Coordinate instance if the coordinates are valid, or PositionError if they are out of range
-    pub fn new(latitude: f64, longitude: f64) -> DwallResult<Self> {
+    /// A new Position instance if the coordinates are valid, or CoordinateError if they are out of range
+    pub fn new(latitude: f64, longitude: f64, altitude: f64) -> DwallResult<Self> {
         if !Self::is_valid_latitude(latitude) {
             return Err(CoordinateError::InvalidLatitude(latitude).into());
         }
@@ -30,13 +32,14 @@ impl Coordinate {
             return Err(CoordinateError::InvalidLongitude(longitude).into());
         }
 
-        Ok(Coordinate {
+        Ok(Position {
             latitude,
             longitude,
+            altitude,
         })
     }
 
-    /// Creates a new Coordinate without validation
+    /// Creates a new Position without validation
     ///
     /// # Safety
     /// This method bypasses coordinate validation. Only use when coordinates
@@ -45,10 +48,12 @@ impl Coordinate {
     /// # Arguments
     /// * `latitude` - Latitude in degrees (should be between -90 and 90)
     /// * `longitude` - Longitude in degrees (should be between -180 and 180)
-    pub(crate) fn from_raw_coordinates(latitude: f64, longitude: f64) -> Self {
-        Coordinate {
+    /// * `altitude` - Altitude in meters (should be negative for underground positions)
+    pub(crate) fn from_raw_position(latitude: f64, longitude: f64, altitude: f64) -> Self {
+        Position {
             latitude,
             longitude,
+            altitude,
         }
     }
 
@@ -69,29 +74,33 @@ impl Coordinate {
     pub fn longitude(&self) -> f64 {
         self.longitude
     }
+
+    pub fn altitude(&self) -> f64 {
+        self.altitude
+    }
 }
 
-impl Default for Coordinate {
+impl Default for Position {
     fn default() -> Self {
-        // Default to coordinates (0, 0) - null island
         Self {
             latitude: 0.0,
             longitude: 0.0,
+            altitude: 0.0,
         }
     }
 }
 
-impl fmt::Display for Coordinate {
+impl fmt::Display for Position {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Coordinate(lat: {}, lng: {})",
-            self.latitude, self.longitude
+            "Position(lat: {}, lng: {}, alt: {})",
+            self.latitude, self.longitude, self.altitude
         )
     }
 }
 
-/// Error type for position-related operations
+/// Error type for coordinate-related operations
 #[derive(Debug, thiserror::Error)]
 pub enum CoordinateError {
     #[error("Invalid latitude: {0}. Must be between -90 and 90 degrees")]
@@ -119,44 +128,45 @@ mod tests {
 
     #[tokio::test]
     async fn test_position_new() {
-        let pos = Coordinate::new(45.0, 90.0).unwrap();
+        let pos = Position::new(45.0, 90.0, 43.5).unwrap();
         assert_eq!(pos.latitude(), 45.0);
         assert_eq!(pos.longitude(), 90.0);
+        assert_eq!(pos.altitude(), 43.5);
     }
 
     #[tokio::test]
     async fn test_position_new_invalid() {
-        assert!(Coordinate::new(91.0, 90.0).is_err());
-        assert!(Coordinate::new(45.0, 181.0).is_err());
-        assert!(Coordinate::new(-91.0, 0.0).is_err());
-        assert!(Coordinate::new(0.0, -181.0).is_err());
+        assert!(Position::new(91.0, 90.0, 43.5).is_err());
+        assert!(Position::new(45.0, 181.0, 43.5).is_err());
+        assert!(Position::new(-91.0, 0.0, 43.5).is_err());
+        assert!(Position::new(0.0, -181.0, 43.5).is_err());
     }
 
     #[tokio::test]
     async fn test_position_validation() {
-        assert!(Coordinate::is_valid_latitude(90.0));
-        assert!(Coordinate::is_valid_latitude(-90.0));
-        assert!(Coordinate::is_valid_latitude(0.0));
-        assert!(!Coordinate::is_valid_latitude(90.1));
-        assert!(!Coordinate::is_valid_latitude(-90.1));
+        assert!(Position::is_valid_latitude(90.0));
+        assert!(Position::is_valid_latitude(-90.0));
+        assert!(Position::is_valid_latitude(0.0));
+        assert!(!Position::is_valid_latitude(90.1));
+        assert!(!Position::is_valid_latitude(-90.1));
 
-        assert!(Coordinate::is_valid_longitude(180.0));
-        assert!(Coordinate::is_valid_longitude(-180.0));
-        assert!(Coordinate::is_valid_longitude(0.0));
-        assert!(!Coordinate::is_valid_longitude(180.1));
-        assert!(!Coordinate::is_valid_longitude(-180.1));
+        assert!(Position::is_valid_longitude(180.0));
+        assert!(Position::is_valid_longitude(-180.0));
+        assert!(Position::is_valid_longitude(0.0));
+        assert!(!Position::is_valid_longitude(180.1));
+        assert!(!Position::is_valid_longitude(-180.1));
     }
 
     #[tokio::test]
     async fn test_position_default() {
-        let pos = Coordinate::default();
+        let pos = Position::default();
         assert_eq!(pos.latitude(), 0.0);
         assert_eq!(pos.longitude(), 0.0);
     }
 
     #[tokio::test]
     async fn test_position_display() {
-        let pos = Coordinate::from_raw_coordinates(45.0, 90.0);
-        assert_eq!(format!("{pos}"), "Coordinate(lat: 45, lng: 90)");
+        let pos = Position::from_raw_position(45.0, 90.0, 43.5);
+        assert_eq!(format!("{pos}"), "Position(lat: 45, lng: 90, alt: 43.5)");
     }
 }

--- a/daemon/src/domain/visual/theme_processor.rs
+++ b/daemon/src/domain/visual/theme_processor.rs
@@ -12,7 +12,7 @@ use tokio::{fs, sync::OnceCell, time::sleep};
 use crate::{
     config::Config,
     domain::{
-        geography::{provider::GeographicPositionProvider, Coordinate},
+        geography::{provider::GeographicPositionProvider, Position},
         time::solar_calculator::{SolarAngle, SunPosition},
         visual::color_scheme::{determine_color_mode, set_color_mode},
     },
@@ -61,9 +61,7 @@ impl<'a> SolarThemeProcessor<'a> {
         let wallpaper_manager = WallpaperSetter::new()?;
 
         Ok(Self {
-            geographic_position_provider: GeographicPositionProvider::new(
-                config.coordinate_source(),
-            ),
+            geographic_position_provider: GeographicPositionProvider::new(config.position_source()),
             config,
             wallpaper_manager,
         })
@@ -187,7 +185,7 @@ impl<'a> SolarThemeProcessor<'a> {
     /// Process solar theme cycle for the current geographic position
     pub(crate) async fn process_solar_theme_cycle(
         &self,
-        geographic_position: &Coordinate,
+        geographic_position: &Position,
     ) -> DwallResult<()> {
         process_solar_theme_cycle(self.config, geographic_position, &self.wallpaper_manager).await
     }
@@ -461,7 +459,7 @@ async fn find_optimal_solar_wallpaper(
 /// Core solar theme processing function that updates wallpapers for all monitors
 async fn process_solar_theme_cycle(
     configuration: &Config,
-    current_geographic_position: &Coordinate,
+    current_geographic_position: &Position,
     wallpaper_manager: &WallpaperSetter,
 ) -> DwallResult<()> {
     debug!(

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -17,7 +17,7 @@ pub use lazy::{DWALL_CACHE_DIR, DWALL_CONFIG_DIR};
 pub use utils::logging::setup_logging;
 
 // Re-export domain types
-pub use domain::geography::Coordinate;
+pub use domain::geography::Position;
 pub use domain::visual::{apply_solar_theme, SolarThemeValidator};
 
 // Re-export infrastructure types
@@ -26,7 +26,7 @@ pub use infrastructure::filesystem::{read_config_file, write_config_file};
 pub use infrastructure::platform::windows::{RegistryError, RegistryKey};
 
 // Backwards compatibility aliases
-pub use domain::geography::Coordinate as GeographicPosition;
 pub use domain::geography::CoordinateError;
 pub use domain::geography::GeolocationAccessError;
+pub use domain::geography::Position as GeographicPosition;
 pub use domain::visual::ColorMode;


### PR DESCRIPTION
- Rename Coordinate enum, struct, and related items to use Position nomenclature
- Add altitude field to Position struct and PositionSource::Manual variant
- Update validation, constructors, and related methods to handle altitude
- Change config field from coordinate_source to position_source with alias support
- Refactor provider to use Position instead of Coordinate, including altitude support
- Update SolarThemeProcessor and other domain usage to reflect Position changes
- Adjust tests to account for altitude and new naming
- Maintain default altitude as 875 meters based on authoritative sources