### PR TITLE
refactor(network): simplify HTTP download stream handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,6 @@ version = "0.1.29"
 dependencies = [
  "dirs",
  "dwall",
- "futures-util",
  "open",
  "rand 0.9.2",
  "reqwest",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,7 +20,6 @@ tauri = { version = "2", default-features = false, features = [
 dwall = { version = "0", path = "../daemon" }
 
 reqwest = { version = "0", default-features = false }
-futures-util = { version = "0", default-features = false }
 zip = { version = "6", default-features = false, features = ["deflate"] }
 open = { version = "5", default-features = false }
 tokio = { workspace = true, features = ["macros", "process"] }


### PR DESCRIPTION
- Remove unused futures-util dependency and related imports
- Replace bytes_stream with direct chunk async iteration on response
- Streamline error handling by using ? operator on chunk await
- Maintain cancellation check and write chunk logic unchanged
- Update Cargo.toml and Cargo.lock to remove futures-util dependency