### PR TITLE
feat(logging): add global lazy-initialized log directory

### DIFF
--- a/daemon/src/lazy.rs
+++ b/daemon/src/lazy.rs
@@ -52,3 +52,30 @@ pub static DWALL_CACHE_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
 
     dir
 });
+
+/// Global log directory path
+///
+/// Initialized lazily on first access. Creates the directory if it doesn't exist.
+/// Uses the application bundle identifier for better organization.
+///
+/// # Panics
+/// Panics if unable to determine user's log directory or create the dwall subdirectory.
+pub static DWALL_LOG_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
+    let log_dir = DWALL_CACHE_DIR.join("log");
+
+    if !log_dir.exists() {
+        if let Err(e) = fs::create_dir(&log_dir) {
+            error!(error = %e, "Failed to create log directory");
+            panic!("Failed to create log directory: {e}");
+        } else {
+            info!(
+                "Log directory created successfully at: {}",
+                log_dir.display()
+            );
+        }
+    } else {
+        debug!(path = %log_dir.display(), "Log directory already exists");
+    }
+
+    log_dir
+});

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -13,7 +13,7 @@ extern crate tracing;
 pub use config::Config;
 pub use core::daemon::DaemonApplication;
 pub use error::DwallResult;
-pub use lazy::{DWALL_CACHE_DIR, DWALL_CONFIG_DIR};
+pub use lazy::{DWALL_CACHE_DIR, DWALL_CONFIG_DIR, DWALL_LOG_DIR};
 pub use utils::logging::setup_logging;
 
 // Re-export domain types

--- a/daemon/src/utils/logging.rs
+++ b/daemon/src/utils/logging.rs
@@ -58,12 +58,11 @@ pub fn setup_logging<S: AsRef<str>>(pkg_names: &[S]) {
     let writer = if cfg!(debug_assertions) {
         BoxMakeWriter::new(Mutex::new(std::io::stderr()))
     } else {
-        use crate::lazy::DWALL_CONFIG_DIR;
+        use crate::lazy::DWALL_LOG_DIR;
         use std::fs::File;
 
-        let log_file =
-            File::create(DWALL_CONFIG_DIR.join(format!("{}.log", pkg_names[0].as_ref())))
-                .expect("Failed to create the log file");
+        let log_file = File::create(DWALL_LOG_DIR.join(format!("{}.log", pkg_names[0].as_ref())))
+            .expect("Failed to create the log file");
         BoxMakeWriter::new(Mutex::new(log_file))
     };
 

--- a/src-tauri/src/app/commands.rs
+++ b/src-tauri/src/app/commands.rs
@@ -11,7 +11,7 @@ use std::{
 use dwall::{
     config::Config, domain::geography::check_location_permission,
     read_config_file as dwall_read_config, write_config_file as dwall_write_config, ColorScheme,
-    DisplayMonitor, DWALL_CONFIG_DIR,
+    DisplayMonitor, DWALL_CONFIG_DIR, DWALL_LOG_DIR,
 };
 use tauri::{AppHandle, Manager, WebviewWindow};
 
@@ -64,6 +64,11 @@ pub async fn open_dir(dir_path: Cow<'_, Path>) -> DwallSettingsResult<()> {
 #[tauri::command]
 pub async fn open_config_dir() -> DwallSettingsResult<()> {
     open::that(DWALL_CONFIG_DIR.as_os_str()).map_err(|e| e.into())
+}
+
+#[tauri::command]
+pub async fn open_log_dir() -> DwallSettingsResult<()> {
+    open::that(DWALL_LOG_DIR.as_os_str()).map_err(|e| e.into())
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -64,6 +64,7 @@ async fn main() -> DwallSettingsResult<()> {
             commands::request_location_permission,
             commands::open_dir,
             commands::open_config_dir,
+            commands::open_log_dir,
             commands::set_titlebar_color_mode,
             commands::move_themes_directory_cmd,
             commands::kill_daemon_cmd,

--- a/src/commands/system.ts
+++ b/src/commands/system.ts
@@ -7,3 +7,5 @@ export const openDir = async (dirPath: string) =>
   invoke<void>("open_dir", { dirPath });
 
 export const killDaemon = async () => invoke<void>("kill_daemon_cmd");
+
+export const openLogDir = async () => invoke<void>("open_log_dir");

--- a/src/components/Settings/Footer.tsx
+++ b/src/components/Settings/Footer.tsx
@@ -5,7 +5,7 @@ import { getVersion } from "@tauri-apps/api/app";
 import { ask, message } from "@tauri-apps/plugin-dialog";
 import { open } from "@tauri-apps/plugin-shell";
 
-import { openConfigDir } from "~/commands";
+import { openLogDir } from "~/commands";
 import { useTranslations, useUpdate } from "~/contexts";
 import {
   LazyButton,
@@ -21,7 +21,7 @@ const SettingsFooter = () => {
   const { update: resource, recheckUpdate, setShowUpdateDialog } = useUpdate();
 
   const onOpenLogDir = async () => {
-    await openConfigDir();
+    await openLogDir();
   };
 
   const onUpdate = async () => {


### PR DESCRIPTION
- Introduce DWALL_LOG_DIR as a lazily initialized global log directory path
- Create the log directory on first access if it does not exist
- Use application bundle identifier for better log directory organization
- Update logging setup to write logs to DWALL_LOG_DIR instead of config directory
- Expose open_log_dir command to open the log directory from frontend
- Add openLogDir frontend command and integrate it into settings footer UI