### PR TITLE
fix(config): validate presence of monitor specific wallpapers

### DIFF
--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -215,6 +215,14 @@ impl Config {
             .into());
         }
 
+        if self.monitor_specific_wallpapers.is_empty() {
+            error!("No monitor specific wallpapers found");
+            return Err(ConfigError::Validation {
+                reason: "No monitor specific wallpapers found".to_string(),
+            }
+            .into());
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
- Add error logging when monitor specific wallpapers list is empty
- Return validation error if no monitor specific wallpapers found
- Prevent proceeding with empty monitor specific wallpapers configuration