### PR TITLE
refactor(daemon): simplify initialization and move logging setup

### DIFF
--- a/daemon/src/bin/daemon.rs
+++ b/daemon/src/bin/daemon.rs
@@ -1,9 +1,11 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use dwall::core::daemon::DaemonApplication;
+use dwall::{core::daemon::DaemonApplication, setup_logging};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> dwall::DwallResult<()> {
-    let mut app = DaemonApplication::new().await?;
+    setup_logging(&[env!("CARGO_PKG_NAME").replace("-", "_")]);
+
+    let mut app = DaemonApplication::new();
     app.run().await
 }

--- a/daemon/src/core/daemon.rs
+++ b/daemon/src/core/daemon.rs
@@ -1,7 +1,6 @@
 use crate::{
     domain::visual::theme_processor::SolarThemeProcessor,
-    infrastructure::filesystem::config_manager::ConfigManager, utils::logging::setup_logging,
-    DwallResult,
+    infrastructure::filesystem::config_manager::ConfigManager, DwallResult,
 };
 
 /// Main daemon application
@@ -11,12 +10,10 @@ pub struct DaemonApplication {
 
 impl DaemonApplication {
     /// Creates a new daemon application instance
-    pub async fn new() -> DwallResult<Self> {
-        setup_logging(&[env!("CARGO_PKG_NAME").replace("-", "_")]);
+    pub fn new() -> Self {
+        let config_manager = ConfigManager::new();
 
-        let config_manager = ConfigManager::new().await?;
-
-        Ok(Self { config_manager })
+        Self { config_manager }
     }
 
     /// Runs the daemon application
@@ -25,5 +22,11 @@ impl DaemonApplication {
 
         let theme_processor = SolarThemeProcessor::new(&config)?;
         theme_processor.start_solar_update_loop().await
+    }
+}
+
+impl Default for DaemonApplication {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/daemon/src/infrastructure/filesystem/config_manager.rs
+++ b/daemon/src/infrastructure/filesystem/config_manager.rs
@@ -15,10 +15,8 @@ pub(crate) struct ConfigManager {
 
 impl ConfigManager {
     /// Creates a new ConfigManager with the default config directory
-    pub(crate) async fn new() -> DwallResult<Self> {
-        Ok(Self {
-            config_path: DWALL_CONFIG_DIR.join("config.toml"),
-        })
+    pub(crate) fn new() -> Self {
+        Self::with_config_dir(&DWALL_CONFIG_DIR)
     }
 
     /// Creates a new ConfigManager with a specific config directory


### PR DESCRIPTION
- Move logging setup to main function for early initialization
- Change DaemonApplication::new to synchronous constructor
- Remove async from ConfigManager::new and DaemonApplication::new methods
- Add Default implementation for DaemonApplication using new()
- Adjust ConfigManager constructor to support default config directory without async
- Clean up unnecessary imports and await usage in daemon code