### PR TITLE
refactor(geography): remove unnecessary async from geolocation functions

### DIFF
--- a/src-tauri/src/app/commands.rs
+++ b/src-tauri/src/app/commands.rs
@@ -150,8 +150,8 @@ pub async fn cancel_theme_download_cmd(
 }
 
 #[tauri::command]
-pub async fn request_location_permission() -> DwallSettingsResult<()> {
-    check_location_permission().await.map_err(Into::into)
+pub fn request_location_permission() -> DwallSettingsResult<()> {
+    check_location_permission().map_err(Into::into)
 }
 
 #[tauri::command]


### PR DESCRIPTION
- Convert handle_windows_error from async to synchronous function
- Remove async keyword from check_location_permission and adjust calls accordingly
- Update get_geo_position to be synchronous and remove all await usages
- Modify Tauri command request_location_permission to be synchronous
- Simplify Windows API calls by removing unnecessary asynchronous handling and awaits
- Preserve error handling and logging while refactoring for sync execution