### PR TITLE
refactor(daemon): remove async runtime and simplify async code to sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,6 @@ dependencies = [
  "tauri-winres",
  "thiserror 2.0.17",
  "time",
- "tokio",
  "toml 0.9.8",
  "tracing",
  "tracing-subscriber",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -27,7 +27,6 @@ toml = { version = "0.9", default-features = false, features = [
   "parse",
   "serde",
 ] }
-tokio = { workspace = true, features = ["sync", "macros", "time", "fs", "rt"] }
 dirs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/daemon/src/bin/daemon.rs
+++ b/daemon/src/bin/daemon.rs
@@ -2,10 +2,9 @@
 
 use dwall::{core::daemon::DaemonApplication, setup_logging};
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> dwall::DwallResult<()> {
+fn main() -> dwall::DwallResult<()> {
     setup_logging(&[env!("CARGO_PKG_NAME").replace("-", "_")]);
 
     let mut app = DaemonApplication::new();
-    app.run().await
+    app.run()
 }

--- a/daemon/src/core/daemon.rs
+++ b/daemon/src/core/daemon.rs
@@ -17,11 +17,11 @@ impl DaemonApplication {
     }
 
     /// Runs the daemon application
-    pub async fn run(&mut self) -> DwallResult<()> {
-        let config = self.config_manager.read_config().await?;
+    pub fn run(&mut self) -> DwallResult<()> {
+        let config = self.config_manager.read_config()?;
 
         let theme_processor = SolarThemeProcessor::new(&config)?;
-        theme_processor.start_solar_update_loop().await
+        theme_processor.start_solar_update_loop()
     }
 }
 

--- a/daemon/src/domain/geography/position.rs
+++ b/daemon/src/domain/geography/position.rs
@@ -126,24 +126,24 @@ pub enum GeolocationAccessError {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn test_position_new() {
+    #[test]
+    fn test_position_new() {
         let pos = Position::new(45.0, 90.0, 43.5).unwrap();
         assert_eq!(pos.latitude(), 45.0);
         assert_eq!(pos.longitude(), 90.0);
         assert_eq!(pos.altitude(), 43.5);
     }
 
-    #[tokio::test]
-    async fn test_position_new_invalid() {
+    #[test]
+    fn test_position_new_invalid() {
         assert!(Position::new(91.0, 90.0, 43.5).is_err());
         assert!(Position::new(45.0, 181.0, 43.5).is_err());
         assert!(Position::new(-91.0, 0.0, 43.5).is_err());
         assert!(Position::new(0.0, -181.0, 43.5).is_err());
     }
 
-    #[tokio::test]
-    async fn test_position_validation() {
+    #[test]
+    fn test_position_validation() {
         assert!(Position::is_valid_latitude(90.0));
         assert!(Position::is_valid_latitude(-90.0));
         assert!(Position::is_valid_latitude(0.0));
@@ -157,15 +157,15 @@ mod tests {
         assert!(!Position::is_valid_longitude(-180.1));
     }
 
-    #[tokio::test]
-    async fn test_position_default() {
+    #[test]
+    fn test_position_default() {
         let pos = Position::default();
         assert_eq!(pos.latitude(), 0.0);
         assert_eq!(pos.longitude(), 0.0);
     }
 
-    #[tokio::test]
-    async fn test_position_display() {
+    #[test]
+    fn test_position_display() {
         let pos = Position::from_raw_position(45.0, 90.0, 43.5);
         assert_eq!(format!("{pos}"), "Position(lat: 45, lng: 90, alt: 43.5)");
     }

--- a/src-tauri/src/app/commands.rs
+++ b/src-tauri/src/app/commands.rs
@@ -42,18 +42,12 @@ pub fn show_window(app: AppHandle, label: &str) -> DwallSettingsResult<()> {
 
 #[tauri::command]
 pub async fn read_config_file() -> DwallSettingsResult<Config> {
-    match dwall_read_config().await {
-        Ok(config) => Ok(config),
-        Err(e) => Err(e.into()),
-    }
+    dwall_read_config().map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn write_config_file(config: Config) -> DwallSettingsResult<()> {
-    match dwall_write_config(&config).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(e.into()),
-    }
+    dwall_write_config(&config).map_err(Into::into)
 }
 
 #[tauri::command]
@@ -84,14 +78,12 @@ pub async fn set_titlebar_color_mode(
 
 #[tauri::command]
 pub async fn get_monitors_cmd() -> DwallSettingsResult<HashMap<String, DisplayMonitor>> {
-    let monitors = get_monitors().await?;
-
-    Ok(monitors)
+    get_monitors().map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn open_privacy_location_settings() -> DwallSettingsResult<()> {
-    open::that("ms-settings:privacy-location").map_err(|e| e.into())
+    open::that("ms-settings:privacy-location").map_err(Into::into)
 }
 
 #[tauri::command]
@@ -99,15 +91,12 @@ pub async fn validate_theme_cmd(
     themes_directory: &Path,
     theme_id: &str,
 ) -> DwallSettingsResult<()> {
-    match validate_solar_theme(themes_directory, theme_id).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(e.into()),
-    }
+    validate_solar_theme(themes_directory, theme_id).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn get_applied_theme_id_cmd(monitor_id: &str) -> DwallSettingsResult<Option<String>> {
-    get_applied_theme_id(monitor_id).await
+    get_applied_theme_id(monitor_id)
 }
 
 #[tauri::command]

--- a/src-tauri/src/domain/monitor.rs
+++ b/src-tauri/src/domain/monitor.rs
@@ -7,6 +7,6 @@ use std::collections::HashMap;
 use dwall::{DisplayMonitor, DisplayMonitorProvider, DwallResult};
 
 /// Get all available monitors
-pub async fn get_monitors() -> DwallResult<HashMap<String, DisplayMonitor>> {
-    DisplayMonitorProvider::new().get_monitors().await
+pub fn get_monitors() -> DwallResult<HashMap<String, DisplayMonitor>> {
+    DisplayMonitorProvider::new().get_monitors()
 }

--- a/src-tauri/src/domain/theme.rs
+++ b/src-tauri/src/domain/theme.rs
@@ -15,11 +15,11 @@ struct DaemonLogEntry {
 }
 
 /// Validates a theme against the solar theme specification
-pub async fn validate_solar_theme(
+pub fn validate_solar_theme(
     themes_directory: &Path,
     theme_id: &str,
 ) -> Result<(), dwall::error::DwallError> {
-    SolarThemeValidator::validate_solar_theme(themes_directory, theme_id).await
+    SolarThemeValidator::validate_solar_theme(themes_directory, theme_id)
 }
 
 /// Attempts to read the most recent error from the daemon log file

--- a/src-tauri/src/infrastructure/filesystem.rs
+++ b/src-tauri/src/infrastructure/filesystem.rs
@@ -59,7 +59,7 @@ pub async fn move_themes_directory(config: Config, dir_path: PathBuf) -> DwallSe
     validate_directory_move(&config, &dir_path)?;
 
     // Prepare new configuration
-    match prepare_new_config(&config, &dir_path).await {
+    match prepare_new_config(&config, &dir_path) {
         Ok(_) => {}
         Err(e) => {
             return Err(e);
@@ -71,7 +71,7 @@ pub async fn move_themes_directory(config: Config, dir_path: PathBuf) -> DwallSe
         Ok(_) => Ok(()),
         Err(e) => {
             // Rollback configuration if move fails
-            if let Err(rollback_err) = write_config_file(&config).await {
+            if let Err(rollback_err) = write_config_file(&config) {
                 error!(original_error = ?e, rollback_error = ?rollback_err, "Critical: Failed to rollback configuration after move failure");
             }
             e.into()
@@ -105,9 +105,9 @@ fn validate_directory_move(config: &Config, destination: &Path) -> DwallSettings
 }
 
 /// Prepares the new configuration
-async fn prepare_new_config(config: &Config, new_path: &Path) -> DwallSettingsResult<()> {
+fn prepare_new_config(config: &Config, new_path: &Path) -> DwallSettingsResult<()> {
     let new_config = config.with_themes_directory(new_path);
-    write_config_file(&new_config).await?;
+    write_config_file(&new_config)?;
 
     Ok(())
 }

--- a/src-tauri/src/services/theme_service.rs
+++ b/src-tauri/src/services/theme_service.rs
@@ -51,7 +51,7 @@ pub fn launch_daemon() -> DwallSettingsResult<()> {
 }
 
 /// Gets the currently applied theme ID for a monitor
-pub async fn get_applied_theme_id(monitor_id: &str) -> DwallSettingsResult<Option<String>> {
+pub fn get_applied_theme_id(monitor_id: &str) -> DwallSettingsResult<Option<String>> {
     // Check if daemon is running
     let daemon_process = find_daemon_process()?;
     if daemon_process.is_none() {
@@ -59,7 +59,7 @@ pub async fn get_applied_theme_id(monitor_id: &str) -> DwallSettingsResult<Optio
     }
 
     // Read current configuration
-    match dwall_read_config().await {
+    match dwall_read_config() {
         Ok(config) => {
             let monitor_themes = config.monitor_specific_wallpapers();
 
@@ -97,7 +97,7 @@ pub async fn apply_theme(config: Config) -> DwallSettingsResult<()> {
         Err(_e) => {}
     }
 
-    dwall_write_config(&config).await?;
+    dwall_write_config(&config)?;
 
     // If no themes are configured, we're done
     if config.monitor_specific_wallpapers().is_empty() {


### PR DESCRIPTION
- Remove tokio dependency and asynchronous runtime in daemon code
- Convert async main and run functions to synchronous versions
- Change async trait methods and tests to synchronous implementations
- Replace tokio synchronization primitives with standard library equivalents
- Refactor filesystem config manager to use std::fs instead of async fs
- Replace async monitor management caching from tokio::RwLock to RefCell
- Replace async wallpaper setter methods with synchronous counterparts
- Modify solar theme processor and validator to operate synchronously
- Update tauri commands to wrap synchronous functions without async
- Remove unnecessary awaits, simplify code paths, and reduce overhead
- Maintain existing functionality with synchronous blocking calls as needed
- Improve overall code clarity and reduce complexity by removing async runtime