### PR TITLE
fix(deps): update tokio dependency versions and features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ tracing-subscriber = { version = "0", default-features = false, features = [
   'env-filter',
   'json',
 ] }
-tokio = { version = "1", default-features = false }
 windows = { version = "0.61", default-features = false }
 
 [profile.release]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ dwall = { version = "0", path = "../daemon" }
 reqwest = { version = "0", default-features = false, features = [] }
 zip = { version = "6", default-features = false, features = ["deflate"] }
 open = { version = "5", default-features = false }
-tokio = { workspace = true, features = ["macros", "process"] }
+tokio = { version = "1", default-features = false, features = ["macros"] }
 dirs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
- Remove tokio dependency from main Cargo.toml
- Change tokio in src-tauri Cargo.toml to version 1 with default-features disabled
- Remove "process" feature from tokio and keep only "macros" feature in src-tauri
- Adjust dependency declaration to match workspace and version constraints