### PR TITLE
refactor(datetime): replace time crate with custom UtcDateTime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,6 @@ dependencies = [
  "serde_json",
  "tauri-winres",
  "thiserror 2.0.17",
- "time",
  "toml 0.9.8",
  "tracing",
  "tracing-subscriber",
@@ -2217,15 +2216,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -4349,9 +4339,7 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -4606,17 +4594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
 ]
 
 [[package]]
@@ -4629,14 +4606,10 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "thread_local",
- "time",
  "tracing",
  "tracing-core",
- "tracing-serde",
 ]
 
 [[package]]
@@ -4768,12 +4741,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,15 @@ edition = "2021"
 [workspace.dependencies]
 dirs = { version = "6", default-features = false }
 thiserror = { version = "2", default-features = false }
-serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = { version = "1", default-features = false }
+serde = { version = "1", default-features = false, features = [
+  "std",
+  "derive",
+] }
+serde_json = { version = "1", default-features = false, features = ["std"] }
 tracing = { version = "0", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0", default-features = false, features = [
   "fmt",
-  'time',
-  "local-time",
   'env-filter',
-  'json',
 ] }
 windows = { version = "0.61", default-features = false }
 

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -18,10 +18,6 @@ path = "src/bin/daemon.rs"
 tauri-winres = { version = "0", optional = true }
 
 [dependencies]
-time = { version = "0", default-features = false, features = [
-  'macros',
-  'serde',
-] }
 toml = { version = "0.9", default-features = false, features = [
   "display",
   "parse",
@@ -31,7 +27,7 @@ dirs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, default-features = false, features = [] }
 tracing-subscriber = { workspace = true }
 windows = { workspace = true, default-features = false, features = [
   "std",

--- a/daemon/src/domain/time/solar_calculator.rs
+++ b/daemon/src/domain/time/solar_calculator.rs
@@ -1,7 +1,8 @@
 //! Solar position calculation utilities for astronomical computations
 
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
+
+use crate::utils::datetime::UtcDateTime;
 
 /// Astronomical calculation constants
 mod constants {
@@ -45,15 +46,15 @@ pub(crate) struct SolarAngle {
 pub(crate) struct SunPosition {
     latitude: f64,
     longitude: f64,
-    date_time: OffsetDateTime,
+    date_time: UtcDateTime,
 }
 
 impl SunPosition {
-    pub(crate) fn new(latitude: f64, longitude: f64, utc_time: OffsetDateTime) -> Self {
+    pub(crate) fn new(latitude: f64, longitude: f64, date_time: UtcDateTime) -> Self {
         Self {
             latitude,
             longitude,
-            date_time: utc_time,
+            date_time,
         }
     }
 
@@ -209,20 +210,19 @@ impl SunPosition {
 
 #[cfg(test)]
 mod tests {
+    use crate::utils::datetime::Month;
+
     use super::*;
-    use time::{Date, Month, Time};
 
     fn create_datetime(
-        year: i32,
+        year: u16,
         month: Month,
         day: u8,
         hour: u8,
         minute: u8,
         second: u8,
-    ) -> OffsetDateTime {
-        let date = Date::from_calendar_date(year, month, day).unwrap();
-        let time = Time::from_hms(hour, minute, second).unwrap();
-        date.with_time(time).assume_utc()
+    ) -> UtcDateTime {
+        UtcDateTime::new(year, month, day, hour, minute, second).unwrap()
     }
 
     fn assert_approx_eq(a: f64, b: f64, epsilon: f64) {

--- a/daemon/src/domain/visual/theme_processor.rs
+++ b/daemon/src/domain/visual/theme_processor.rs
@@ -9,8 +9,6 @@ use std::{
     time::Duration,
 };
 
-use time::OffsetDateTime;
-
 use crate::{
     config::Config,
     domain::{
@@ -22,6 +20,7 @@ use crate::{
         },
     },
     infrastructure::display::wallpaper_setter::WallpaperSetter,
+    utils::datetime::UtcDateTime,
     DwallResult,
 };
 
@@ -79,15 +78,13 @@ impl<'a> SolarThemeProcessor<'a> {
             "Starting solar-based theme update loop"
         );
 
-        let mut last_update_timestamp =
-            OffsetDateTime::now_local().unwrap_or(OffsetDateTime::now_utc());
+        let mut last_update_timestamp = UtcDateTime::now();
         let mut consecutive_failure_count = 0;
 
         let update_interval_duration = Duration::from_secs(self.config.interval().into());
 
         loop {
-            let current_timestamp =
-                OffsetDateTime::now_local().unwrap_or(OffsetDateTime::now_utc());
+            let current_timestamp = UtcDateTime::now();
             debug!(
                 last_update_timestamp = %last_update_timestamp,
                 current_timestamp = %current_timestamp,
@@ -473,7 +470,7 @@ fn process_solar_theme_cycle(
     let available_monitors = wallpaper_manager.list_available_monitors()?;
     let monitor_theme_configurations = configuration.monitor_specific_wallpapers();
 
-    let current_utc_time = OffsetDateTime::now_utc();
+    let current_utc_time = UtcDateTime::now();
     let current_sun_position = SunPosition::new(
         current_geographic_position.latitude(),
         current_geographic_position.longitude(),

--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -40,10 +40,6 @@ pub enum DwallError {
     #[error("String contains null character: {0}")]
     NulError(#[from] std::ffi::NulError),
 
-    /// Time offset error
-    #[error("Unable to determine time offset: {0}")]
-    TimeIndeterminateOffset(#[from] time::error::IndeterminateOffset),
-
     /// Monitor related error
     #[error("Monitor operation failed: {0}")]
     Monitor(#[from] DisplayError),
@@ -55,10 +51,6 @@ pub enum DwallError {
     /// Geolocation access error
     #[error("Geolocation access error: {0}")]
     GeolocationAccess(#[from] GeolocationAccessError),
-
-    /// Timeout error
-    #[error("Operation timed out: {0}")]
-    Timeout(String),
 
     /// Wallpaper manager error
     #[error("Wallpaper operation failed: {0}")]

--- a/daemon/src/utils/datetime/consts.rs
+++ b/daemon/src/utils/datetime/consts.rs
@@ -1,0 +1,57 @@
+// === Time unit conversions ===
+pub(super) const SECONDS_PER_MINUTE: u64 = 60;
+pub(super) const SECONDS_PER_HOUR: u64 = 3600; // 60 * 60
+pub(super) const SECONDS_PER_DAY: u64 = 86400; // 24 * 3600
+
+// === Gregorian calendar cycle constants (based on the proleptic Gregorian calendar) ===
+
+/// Total number of days in a 400-year cycle.
+///
+/// The Gregorian calendar has 97 leap years every 400 years (years divisible by 4 but not by 100,
+/// unless also divisible by 400).
+/// Calculation: 400 * 365 + 97 = 146,097 days.
+pub(super) const DAYS_PER_400_YEARS: u32 = 146097;
+
+/// Total number of days in a 100-year cycle (not a complete Gregorian cycle, used for auxiliary calculations).
+///
+/// In a 100-year period, there are typically 24 leap years (since the 100th year is not a leap year
+/// unless it's divisible by 400).
+/// Calculation: 100 * 365 + 24 = 36,524 days.
+pub(super) const DAYS_PER_100_YEARS: u32 = 36524;
+
+/// Total number of days in a 4-year cycle (including one leap year).
+///
+/// Calculation: 4 * 365 + 1 = 1,461 days.
+pub(super) const DAYS_PER_4_YEARS: u32 = 1461;
+
+/// Number of days in a common (non-leap) year.
+pub(super) const DAYS_PER_YEAR: u32 = 365;
+
+/// Number of days from the Unix epoch (1970-01-01) to the algorithm's reference date (March 1, year 0).
+///
+/// The algorithm uses March 1 of year 0 (0000-03-01) as its reference date, which offers advantages:
+/// 1. Each year starts in March, placing the leap day (February 29) at the end of the year, simplifying calculations.
+/// 2. Avoids leap-year edge cases when handling January and February.
+///
+/// 719,468 = number of days between 1970-01-01 and 0000-03-01.
+pub(super) const UNIX_EPOCH_TO_MARCH_1_YEAR_0: u32 = 719468;
+
+/// Month conversion magic constant.
+///
+/// Used to quickly map "day-of-year counted from March 1" to a month index via division.
+/// The formula `(5 * day_of_year + 2) / 153` maps day-of-year to a month index (March = 0 through February = 11).
+/// The value 153 is derived mathematically from the pattern of month lengths starting in March.
+pub(super) const MONTH_DIVISOR: u32 = 153;
+
+// === Cumulative days tables ===
+
+/// Precomputed cumulative days table [common year, leap year].
+///
+/// Index `i` represents the cumulative number of days at the start of the `i`-th month (0-based,
+/// so it actually corresponds to month `i+1`).
+pub(super) const CUMULATIVE_DAYS: [[u32; 13]; 2] = [
+    // Common year: cumulative days at the start of each month (index 0 = Jan 1 = day 0)
+    [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365],
+    // Leap year
+    [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366],
+];

--- a/daemon/src/utils/datetime/error.rs
+++ b/daemon/src/utils/datetime/error.rs
@@ -1,0 +1,35 @@
+use std::time::SystemTimeError;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DateTimeError {
+    #[error("Year must be >= 1970, got {0}")]
+    InvalidYear(u16),
+
+    #[error("Day {0} is invalid for the given month")]
+    InvalidDay(u8),
+
+    #[error("Hour must be < 24, got {0}")]
+    InvalidHour(u8),
+
+    #[error("Minute must be < 60, got {0}")]
+    InvalidMinute(u8),
+
+    #[error("Second must be < 60, got {0}")]
+    InvalidSecond(u8),
+
+    #[error("System time error: {0}")]
+    SystemTime(#[from] SystemTimeError),
+
+    #[error("Arithmetic overflow in date calculation")]
+    Overflow,
+
+    #[error("Invalid month value: {0}")]
+    InvalidMonth(u8),
+
+    #[error("Time difference would be negative")]
+    NegativeDuration,
+}
+
+pub type DateTimeResult<T> = Result<T, DateTimeError>;

--- a/daemon/src/utils/datetime/math.rs
+++ b/daemon/src/utils/datetime/math.rs
@@ -1,0 +1,238 @@
+use crate::utils::datetime::{
+    consts::{
+        CUMULATIVE_DAYS, DAYS_PER_100_YEARS, DAYS_PER_400_YEARS, DAYS_PER_4_YEARS, DAYS_PER_YEAR,
+        MONTH_DIVISOR, UNIX_EPOCH_TO_MARCH_1_YEAR_0,
+    },
+    error::DateTimeResult,
+    month::Month,
+};
+
+#[inline]
+pub(super) const fn is_leap_year(year: u16) -> bool {
+    // Rust 1.87.0+ supports is_multiple_of
+    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
+}
+
+/// Converts a Gregorian calendar date into the number of days since the Unix epoch (1970-01-01).
+pub(super) fn days_since_epoch(year: u16, month: Month, day: u8) -> DateTimeResult<u32> {
+    let years_since_epoch = year as u32 - 1970;
+
+    // Compute total days from complete years
+    let leap_years = count_leap_years(1970, year);
+    let mut days = years_since_epoch * DAYS_PER_YEAR + leap_years;
+
+    // Use lookup table for fast cumulative days up to the given month
+    let is_leap = is_leap_year(year);
+    let table = &CUMULATIVE_DAYS[is_leap as usize];
+    days += table[(month as u8 - 1) as usize];
+
+    // Add the day of the month (convert to 0-based)
+    days += day as u32 - 1;
+    Ok(days)
+}
+
+/// Counts the number of leap years in the half-open interval [start, end).
+///
+/// This function calculates how many leap years occur from `start` (inclusive)
+/// to `end` (exclusive). For example, `count_leap_years(2024, 2025)` returns 1
+/// because 2024 is a leap year and is included in the range.
+///
+/// The algorithm uses the standard Gregorian calendar leap year rules:
+/// - A year is a leap year if divisible by 4
+/// - Except if divisible by 100, unless also divisible by 400
+///
+/// Then computes: leap_years_up_to(end - 1) - leap_years_up_to(start - 1)
+///
+/// # Arguments
+/// * `start` - Starting year (inclusive), must be >= 1970 per requirements
+/// * `end` - Ending year (exclusive), must be >= start
+#[inline]
+fn count_leap_years(start: u16, end: u16) -> u32 {
+    let count = |year: u16| -> u32 {
+        let y = year as u32;
+        (y / 4) - (y / 100) + (y / 400)
+    };
+    count(end - 1) - count(start - 1)
+}
+
+/// Converts the number of days since the Unix epoch into a Gregorian calendar date.
+///
+/// This algorithm is based on Howard Hinnant's efficient date algorithm.
+/// The input `days` represents the number of days elapsed since the Unix epoch (1970-01-01). See: <https://howardhinnant.github.io/date_algorithms.html>
+///
+/// The algorithm shifts the year start to March 1st, placing the leap day at the end of the year,
+/// which simplifies leap year handling.
+///
+/// Returns: (year, month, day)
+pub(super) fn days_to_ymd(days: u32) -> (u16, Month, u8) {
+    // Convert input days to days since March 1 of year 0
+    let days_from_base = days + UNIX_EPOCH_TO_MARCH_1_YEAR_0;
+
+    // Compute the number of full 400-year cycles (eras) and remaining days within the current era
+    let era = days_from_base / DAYS_PER_400_YEARS;
+    let day_of_era = days_from_base % DAYS_PER_400_YEARS;
+
+    // Compute the year within the current 400-year era (0–399)
+    // This accounts for leap year rules: leap every 4 years, except centuries, unless divisible by 400
+    let year_of_era = (day_of_era - day_of_era / (DAYS_PER_4_YEARS - 1)
+        + day_of_era / DAYS_PER_100_YEARS
+        - day_of_era / (DAYS_PER_400_YEARS - 1))
+        / DAYS_PER_YEAR;
+
+    // Compute the year counting from year 0 with March 1 as the start of the year
+    let year_starting_march = year_of_era + era * 400;
+
+    // Compute the day of the year (0-based, where March 1 = 0)
+    let day_of_year =
+        day_of_era - (DAYS_PER_YEAR * year_of_era + year_of_era / 4 - year_of_era / 100);
+
+    // Map day-of-year to month index (March = 0, April = 1, ..., February = 11)
+    let month_index = (5 * day_of_year + 2) / MONTH_DIVISOR;
+
+    // Compute the day of the month (1-based)
+    let day = day_of_year - (MONTH_DIVISOR * month_index + 2) / 5 + 1;
+
+    // Convert to standard calendar month (March–December = 3–12; January–February = 1–2)
+    let month = if month_index < 10 {
+        month_index + 3 // March–December
+    } else {
+        month_index - 9 // January–February
+    };
+
+    // Adjust year: January and February belong to the next calendar year
+    let year = year_starting_march + if month <= 2 { 1 } else { 0 };
+
+    (
+        year as u16,
+        Month::from_u8_unchecked(month as u8),
+        day as u8,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_leap_year() {
+        // Standard leap years
+        assert!(is_leap_year(2000));
+        assert!(is_leap_year(2004));
+        assert!(is_leap_year(2024));
+
+        // Non-leap years
+        assert!(!is_leap_year(1900));
+        assert!(!is_leap_year(2100));
+        assert!(!is_leap_year(2023));
+        assert!(!is_leap_year(2025));
+
+        // Edge cases
+        assert!(is_leap_year(4)); // First leap year
+        assert!(!is_leap_year(1)); // Year 1 is not leap
+        assert!(is_leap_year(400)); // Divisible by 400
+    }
+
+    #[test]
+    fn test_count_leap_years() {
+        // From 1970 to 1970 → 0
+        assert_eq!(count_leap_years(1970, 1970), 0);
+        // From 1970 to 1973 → includes 1972 → 1
+        assert_eq!(count_leap_years(1970, 1973), 1);
+        // From 1970 to 1977 → includes 1972, 1976 → 2
+        assert_eq!(count_leap_years(1970, 1977), 2);
+        // From 1970 to 2001 → includes 1972,76,80,84,88,92,96,2000 → 8
+        assert_eq!(count_leap_years(1970, 2001), 8);
+        // Across century: 1896 to 1905 → only 1896 and 1904 (1900 not leap)
+        assert_eq!(count_leap_years(1896, 1905), 2);
+    }
+
+    #[test]
+    fn test_days_to_ymd() {
+        let test_cases = vec![
+            // Basic epoch
+            (0, (1970, Month::January, 1)),
+            // End of January
+            (30, (1970, Month::January, 31)),
+            // End of February (non-leap)
+            (58, (1970, Month::February, 28)),
+            // March 1
+            (59, (1970, Month::March, 1)),
+            // Leap year: 2000
+            (10957, (2000, Month::January, 1)),   // 2000-01-01
+            (11016, (2000, Month::February, 29)), // Feb 29, 2000
+            (11017, (2000, Month::March, 1)),
+            // Non-leap century: 2100
+            (47540, (2100, Month::February, 28)),
+            (47541, (2100, Month::March, 1)),
+            // Far future
+            (100000, (2243, Month::October, 17)),
+            // Year 2038 boundary
+            (29220, (2050, Month::January, 1)),
+        ];
+
+        for (days, expected) in test_cases {
+            let (year, month, day) = days_to_ymd(days);
+            assert_eq!((year, month, day), expected, "Failed for days = {}", days);
+        }
+    }
+
+    #[test]
+    fn test_days_since_epoch() {
+        let test_cases = vec![
+            (1970, Month::January, 1, 0),
+            (1970, Month::January, 31, 30),
+            (1970, Month::February, 28, 58),
+            (1970, Month::March, 1, 59),
+            (2000, Month::January, 1, 10957),
+            (2000, Month::February, 29, 11016),
+            (2000, Month::March, 1, 11017),
+            (2100, Month::February, 28, 47540),
+            (2100, Month::March, 1, 47541),
+            (2243, Month::October, 17, 100000),
+        ];
+
+        for (year, month, day, expected_days) in test_cases {
+            let days = days_since_epoch(year, month, day).unwrap();
+            assert_eq!(
+                days, expected_days,
+                "Failed for {}-{:?}-{}",
+                year, month, day
+            );
+        }
+    }
+
+    #[test]
+    fn test_round_trip_consistency() {
+        let dates = vec![
+            (1970, Month::January, 1),
+            (1970, Month::December, 31),
+            (1999, Month::December, 31),
+            (2000, Month::February, 29),
+            (2001, Month::March, 1),
+            (2024, Month::February, 29),
+            (2100, Month::February, 28),
+            (2200, Month::June, 15),
+        ];
+
+        for (year, month, day) in dates {
+            let days = days_since_epoch(year, month, day).unwrap();
+            let (y, m, d) = days_to_ymd(days);
+            assert_eq!(
+                (y, m, d),
+                (year, month, day),
+                "Round-trip failed for {}-{:?}-{}",
+                year,
+                month,
+                day
+            );
+        }
+    }
+
+    #[test]
+    fn test_february_29_edge_cases() {
+        // Valid leap day
+        let days = days_since_epoch(2024, Month::February, 29).unwrap();
+        let (y, m, d) = days_to_ymd(days);
+        assert_eq!((y, m, d), (2024, Month::February, 29));
+    }
+}

--- a/daemon/src/utils/datetime/mod.rs
+++ b/daemon/src/utils/datetime/mod.rs
@@ -1,0 +1,465 @@
+mod consts;
+mod error;
+mod math;
+mod month;
+
+use std::fmt;
+use std::time::{Duration, SystemTime};
+
+use crate::utils::datetime::consts::{SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE};
+use crate::utils::datetime::error::{DateTimeError, DateTimeResult};
+use crate::utils::datetime::math::{days_since_epoch, days_to_ymd, is_leap_year};
+
+pub use crate::utils::datetime::month::Month;
+
+/// UTC date-time structure
+///
+/// # Performance considerations
+/// - Methods `year()`, `month()`, and `day()` involve computation; it is recommended to use `ymd()` or `ymd_hms()` to fetch all values at once.
+/// - Timestamp operations (e.g., `timestamp()`, `add_seconds()`) are O(1).
+/// - `ymd()` and `ymd_hms()` use optimized O(1) algorithms combined with lookup tables.
+///
+/// # Leap second note
+/// This implementation does not support leap seconds (second must be < 60). Unix timestamps themselves do not include leap second information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct UtcDateTime {
+    inner: Duration,
+}
+
+impl UtcDateTime {
+    /// Creates a new UTC date-time with the specified components.
+    pub fn new(
+        year: u16,
+        month: Month,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+    ) -> DateTimeResult<Self> {
+        // Validate input parameters
+        if year < 1970 {
+            return Err(DateTimeError::InvalidYear(year));
+        }
+        if day == 0 || day > month.days_in_month(year) {
+            return Err(DateTimeError::InvalidDay(day));
+        }
+        if hour >= 24 {
+            return Err(DateTimeError::InvalidHour(hour));
+        }
+        if minute >= 60 {
+            return Err(DateTimeError::InvalidMinute(minute));
+        }
+        // Leap seconds are not supported
+        if second >= 60 {
+            return Err(DateTimeError::InvalidSecond(second));
+        }
+
+        let days = days_since_epoch(year, month, day)?;
+        let total_seconds = days as u64 * SECONDS_PER_DAY
+            + hour as u64 * SECONDS_PER_HOUR
+            + minute as u64 * SECONDS_PER_MINUTE
+            + second as u64;
+
+        Ok(Self {
+            inner: Duration::from_secs(total_seconds),
+        })
+    }
+
+    /// Gets the current UTC time.
+    #[inline]
+    pub fn now() -> Self {
+        let duration = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Invalid system time");
+        Self { inner: duration }
+    }
+
+    /// Creates a new UTC date-time from a Unix timestamp (seconds).
+    #[inline]
+    pub const fn from_timestamp(secs: u64) -> Self {
+        Self {
+            inner: Duration::from_secs(secs),
+        }
+    }
+
+    /// Creates a new UTC date-time from a Unix timestamp (milliseconds).
+    #[inline]
+    pub const fn from_timestamp_millis(millis: u64) -> Self {
+        Self {
+            inner: Duration::from_millis(millis),
+        }
+    }
+
+    /// Gets the Unix timestamp (seconds).
+    #[inline]
+    pub const fn timestamp(&self) -> u64 {
+        self.inner.as_secs()
+    }
+
+    /// Gets the Unix timestamp (milliseconds).
+    #[inline]
+    pub const fn timestamp_millis(&self) -> u64 {
+        self.inner.as_millis() as u64
+    }
+
+    /// Returns the year.
+    ///
+    /// Note: If you need year, month, and day together, use `ymd()` or `ymd_hms()` for better performance.
+    #[inline]
+    pub fn year(&self) -> u16 {
+        let (year, _, _) = self.ymd();
+        year
+    }
+
+    /// Returns the month.
+    ///
+    /// Note: If you need year, month, and day together, use `ymd()` or `ymd_hms()` for better performance.
+    #[inline]
+    pub fn month(&self) -> Month {
+        let (_, month, _) = self.ymd();
+        month
+    }
+
+    /// Returns the day of the month.
+    ///
+    /// Note: If you need year, month, and day together, use `ymd()` or `ymd_hms()` for better performance.
+    #[inline]
+    pub fn day(&self) -> u8 {
+        let (_, _, day) = self.ymd();
+        day
+    }
+
+    /// Returns the hour (0–23).
+    #[inline]
+    pub const fn hour(&self) -> u8 {
+        ((self.inner.as_secs() % SECONDS_PER_DAY) / SECONDS_PER_HOUR) as u8
+    }
+
+    /// Returns the minute (0–59).
+    #[inline]
+    pub const fn minute(&self) -> u8 {
+        ((self.inner.as_secs() % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE) as u8
+    }
+
+    /// Returns the second (0–59).
+    #[inline]
+    pub const fn second(&self) -> u8 {
+        (self.inner.as_secs() % SECONDS_PER_MINUTE) as u8
+    }
+
+    /// Returns the millisecond component (0–999).
+    #[inline]
+    pub const fn millisecond(&self) -> u16 {
+        (self.inner.as_millis() % 1000) as u16
+    }
+
+    /// Returns the year, month, and day (recommended for fetching multiple date components efficiently).
+    #[inline]
+    pub fn ymd(&self) -> (u16, Month, u8) {
+        let days = (self.inner.as_secs() / SECONDS_PER_DAY) as u32;
+        days_to_ymd(days)
+    }
+
+    /// Returns the hour, minute, and second.
+    #[inline]
+    pub const fn hms(&self) -> (u8, u8, u8) {
+        (self.hour(), self.minute(), self.second())
+    }
+
+    /// Returns year, month, day, hour, minute, and second (more efficient than calling individual methods).
+    #[inline]
+    pub fn ymd_hms(&self) -> (u16, Month, u8, u8, u8, u8) {
+        let (y, m, d) = self.ymd();
+        let (h, min, s) = self.hms();
+        (y, m, d, h, min, s)
+    }
+
+    /// Adds the specified number of seconds.
+    #[inline]
+    pub fn add_seconds(&self, secs: u64) -> DateTimeResult<Self> {
+        self.inner
+            .checked_add(Duration::from_secs(secs))
+            .map(|inner| Self { inner })
+            .ok_or(DateTimeError::Overflow)
+    }
+
+    /// Adds the specified number of minutes.
+    #[inline]
+    pub fn add_minutes(&self, mins: u64) -> DateTimeResult<Self> {
+        self.add_seconds(
+            mins.checked_mul(SECONDS_PER_MINUTE)
+                .ok_or(DateTimeError::Overflow)?,
+        )
+    }
+
+    /// Adds the specified number of hours.
+    #[inline]
+    pub fn add_hours(&self, hours: u64) -> DateTimeResult<Self> {
+        self.add_seconds(
+            hours
+                .checked_mul(SECONDS_PER_HOUR)
+                .ok_or(DateTimeError::Overflow)?,
+        )
+    }
+
+    /// Adds the specified number of days.
+    #[inline]
+    pub fn add_days(&self, days: u64) -> DateTimeResult<Self> {
+        self.add_seconds(
+            days.checked_mul(SECONDS_PER_DAY)
+                .ok_or(DateTimeError::Overflow)?,
+        )
+    }
+
+    /// Subtracts the specified number of seconds.
+    #[inline]
+    pub fn sub_seconds(&self, secs: u64) -> DateTimeResult<Self> {
+        self.inner
+            .checked_sub(Duration::from_secs(secs))
+            .map(|inner| Self { inner })
+            .ok_or(DateTimeError::Overflow)
+    }
+
+    /// Subtracts the specified number of minutes.
+    #[inline]
+    pub fn sub_minutes(&self, mins: u64) -> DateTimeResult<Self> {
+        self.sub_seconds(
+            mins.checked_mul(SECONDS_PER_MINUTE)
+                .ok_or(DateTimeError::Overflow)?,
+        )
+    }
+
+    /// Subtracts the specified number of hours.
+    #[inline]
+    pub fn sub_hours(&self, hours: u64) -> DateTimeResult<Self> {
+        self.sub_seconds(
+            hours
+                .checked_mul(SECONDS_PER_HOUR)
+                .ok_or(DateTimeError::Overflow)?,
+        )
+    }
+
+    /// Subtracts the specified number of days.
+    #[inline]
+    pub fn sub_days(&self, days: u64) -> DateTimeResult<Self> {
+        self.sub_seconds(
+            days.checked_mul(SECONDS_PER_DAY)
+                .ok_or(DateTimeError::Overflow)?,
+        )
+    }
+
+    /// Returns the start of the day (00:00:00).
+    #[inline]
+    pub fn start_of_day(&self) -> Self {
+        let days = self.inner.as_secs() / SECONDS_PER_DAY;
+        Self {
+            inner: Duration::from_secs(days * SECONDS_PER_DAY),
+        }
+    }
+
+    /// Returns the end of the day (23:59:59).
+    #[inline]
+    pub fn end_of_day(&self) -> Self {
+        let days = self.inner.as_secs() / SECONDS_PER_DAY;
+        Self {
+            inner: Duration::from_secs((days + 1) * SECONDS_PER_DAY - 1),
+        }
+    }
+
+    /// Computes the difference between this and another time in seconds.
+    ///
+    /// Note: The result may be negative if `self < other`.
+    #[inline]
+    pub fn diff_seconds(&self, other: &Self) -> i64 {
+        self.inner.as_secs() as i64 - other.inner.as_secs() as i64
+    }
+
+    /// Computes the difference between this and another time in days.
+    ///
+    /// Note: The result may be negative if `self < other`.
+    #[inline]
+    pub fn diff_days(&self, other: &Self) -> i64 {
+        self.diff_seconds(other) / SECONDS_PER_DAY as i64
+    }
+
+    /// Computes the duration between this and another time.
+    ///
+    /// Returns an error if `self < other`.
+    #[inline]
+    pub fn duration_since(&self, other: &Self) -> DateTimeResult<Duration> {
+        if self.inner >= other.inner {
+            Ok(self.inner - other.inner)
+        } else {
+            Err(DateTimeError::NegativeDuration)
+        }
+    }
+
+    /// Checks if this time is before the given time.
+    #[inline]
+    pub const fn is_before(&self, other: &Self) -> bool {
+        self.inner.as_secs() < other.inner.as_secs()
+    }
+
+    /// Checks if this time is after the given time.
+    #[inline]
+    pub const fn is_after(&self, other: &Self) -> bool {
+        self.inner.as_secs() > other.inner.as_secs()
+    }
+
+    /// Checks if this time falls within the inclusive range [start, end].
+    #[inline]
+    pub const fn is_between_inclusive(&self, start: &Self, end: &Self) -> bool {
+        self.inner.as_secs() >= start.inner.as_secs() && self.inner.as_secs() <= end.inner.as_secs()
+    }
+
+    /// Checks if this time falls within the exclusive range (start, end).
+    #[inline]
+    pub const fn is_between_exclusive(&self, start: &Self, end: &Self) -> bool {
+        self.inner.as_secs() > start.inner.as_secs() && self.inner.as_secs() < end.inner.as_secs()
+    }
+
+    /// Formats the date and time as an RFC 3339 string (YYYY-MM-DDTHH:MM:SS.mmmZ).
+    #[inline]
+    pub fn to_rfc3339(&self) -> String {
+        let (year, month, day) = self.ymd();
+        let (hour, minute, second) = self.hms();
+        format!(
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+            year,
+            month as u8,
+            day,
+            hour,
+            minute,
+            second,
+            self.millisecond()
+        )
+    }
+
+    /// Checks if the year of this date is a leap year.
+    #[inline]
+    pub fn is_leap_year(&self) -> bool {
+        is_leap_year(self.year())
+    }
+}
+
+impl Default for UtcDateTime {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            inner: Duration::from_secs(0), // Unix epoch
+        }
+    }
+}
+
+impl fmt::Display for UtcDateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_rfc3339())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_and_components() {
+        let dt = UtcDateTime::new(2024, Month::March, 15, 10, 30, 45).unwrap();
+        assert_eq!(dt.year(), 2024);
+        assert_eq!(dt.month(), Month::March);
+        assert_eq!(dt.day(), 15);
+        assert_eq!(dt.hour(), 10);
+        assert_eq!(dt.minute(), 30);
+        assert_eq!(dt.second(), 45);
+    }
+
+    #[test]
+    fn test_arithmetic() {
+        let dt = UtcDateTime::from_timestamp(1000000);
+        let dt2 = dt.add_days(1).unwrap();
+        assert_eq!(dt2.timestamp(), 1000000 + SECONDS_PER_DAY);
+
+        let dt3 = dt2.sub_hours(2).unwrap();
+        assert_eq!(
+            dt3.timestamp(),
+            1000000 + SECONDS_PER_DAY - 2 * SECONDS_PER_HOUR
+        );
+    }
+
+    #[test]
+    fn test_ymd_hms() {
+        let test_cases = vec![
+            (1970, Month::January, 1, 0, 0, 0),
+            (2025, Month::January, 1, 12, 30, 45),
+            (2100, Month::January, 1, 12, 30, 45),
+            (2100, Month::February, 28, 14, 30, 45),
+        ];
+
+        for case in test_cases {
+            let dt = UtcDateTime::new(case.0, case.1, case.2, case.3, case.4, case.5).unwrap();
+            let ymd_hms = dt.ymd_hms();
+
+            assert_eq!(ymd_hms, case);
+        }
+    }
+
+    #[test]
+    fn test_leap_year_boundary() {
+        // test leap year February boundary
+        let dt1 = UtcDateTime::new(2024, Month::February, 29, 0, 0, 0).unwrap();
+        assert_eq!(dt1.day(), 29);
+
+        // test non-leap year February boundary
+        let result = UtcDateTime::new(2023, Month::February, 29, 0, 0, 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_roundtrip_conversion() {
+        // test ymd -> timestamp -> ymd
+        let test_dates = vec![
+            (2025, Month::January, 1),
+            (2025, Month::December, 31),
+            (2050, Month::June, 15),
+            (2100, Month::February, 28),
+        ];
+
+        for (y, m, d) in test_dates {
+            let dt = UtcDateTime::new(y, m, d, 12, 30, 45).unwrap();
+            let ts = dt.timestamp();
+            let dt2 = UtcDateTime::from_timestamp(ts);
+            assert_eq!(dt2.ymd(), (y, m, d));
+        }
+    }
+
+    #[test]
+    fn test_leap_second_rejection() {
+        // test rejection of leap seconds
+        let result = UtcDateTime::new(2025, Month::June, 30, 23, 59, 60);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_start_end_of_day() {
+        let dt = UtcDateTime::new(2025, Month::June, 15, 14, 30, 45).unwrap();
+
+        let start = dt.start_of_day();
+        assert_eq!(start.hms(), (0, 0, 0));
+        assert_eq!(start.day(), 15);
+
+        let end = dt.end_of_day();
+        assert_eq!(end.hms(), (23, 59, 59));
+        assert_eq!(end.day(), 15);
+    }
+
+    #[test]
+    fn test_comparison_methods() {
+        let dt1 = UtcDateTime::from_timestamp(1000);
+        let dt2 = UtcDateTime::from_timestamp(2000);
+        let dt3 = UtcDateTime::from_timestamp(3000);
+
+        assert!(dt1.is_before(&dt2));
+        assert!(dt3.is_after(&dt2));
+        assert!(dt2.is_between_inclusive(&dt1, &dt3));
+        assert!(!dt1.is_between_exclusive(&dt1, &dt3));
+    }
+}

--- a/daemon/src/utils/datetime/month.rs
+++ b/daemon/src/utils/datetime/month.rs
@@ -1,0 +1,90 @@
+use crate::utils::datetime::{error::DateTimeError, math::is_leap_year};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Month {
+    January = 1,
+    February = 2,
+    March = 3,
+    April = 4,
+    May = 5,
+    June = 6,
+    July = 7,
+    August = 8,
+    September = 9,
+    October = 10,
+    November = 11,
+    December = 12,
+}
+
+impl Month {
+    #[inline]
+    pub(super) const fn days_in_month(self, year: u16) -> u8 {
+        match self {
+            Month::January
+            | Month::March
+            | Month::May
+            | Month::July
+            | Month::August
+            | Month::October
+            | Month::December => 31,
+            Month::April | Month::June | Month::September | Month::November => 30,
+            Month::February => {
+                if is_leap_year(year) {
+                    29
+                } else {
+                    28
+                }
+            }
+        }
+    }
+
+    /// Internal use: creates a Month from a valid u8 value (without validation)
+    ///
+    /// # Safety
+    /// The caller must ensure that `value` is within the range 1..=12.
+    #[inline]
+    pub(super) const fn from_u8_unchecked(value: u8) -> Self {
+        match value {
+            1 => Month::January,
+            2 => Month::February,
+            3 => Month::March,
+            4 => Month::April,
+            5 => Month::May,
+            6 => Month::June,
+            7 => Month::July,
+            8 => Month::August,
+            9 => Month::September,
+            10 => Month::October,
+            11 => Month::November,
+            _ => Month::December,
+        }
+    }
+
+    #[inline]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl TryFrom<u8> for Month {
+    type Error = DateTimeError;
+
+    #[inline]
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Month::January),
+            2 => Ok(Month::February),
+            3 => Ok(Month::March),
+            4 => Ok(Month::April),
+            5 => Ok(Month::May),
+            6 => Ok(Month::June),
+            7 => Ok(Month::July),
+            8 => Ok(Month::August),
+            9 => Ok(Month::September),
+            10 => Ok(Month::October),
+            11 => Ok(Month::November),
+            12 => Ok(Month::December),
+            _ => Err(DateTimeError::InvalidMonth(value)),
+        }
+    }
+}

--- a/daemon/src/utils/mod.rs
+++ b/daemon/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod datetime;
 pub mod helpers;
 pub mod logging;
 pub mod string;


### PR DESCRIPTION
- Remove usage of the external time crate from daemon module and Cargo dependencies
- Implement a new UtcDateTime struct with efficient O(1) date/time calculations
- Provide comprehensive date/time functionality including creation, arithmetic, comparisons, and formatting
- Add detailed error handling for invalid date/time components and arithmetic overflows
- Replace solar_calculator and theme_processor modules to use UtcDateTime instead of time::OffsetDateTime
- Introduce internal datetime utility modules: consts, error, math, month for modular design
- Add extensive unit tests covering date conversions, leap years, arithmetic, and boundary cases
- Clean up dependencies by removing obsolete crates such as num_threads, valuable, and tracing-serde
- Modify Cargo.toml to adjust serde and tracing features and remove time crate dependencies accordingly