### PR TITLE
fix(ci): specify fixed feature flag for release publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -178,7 +178,7 @@ jobs:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           releaseBody: ${{ needs.create-release.outputs.changelog }}
           updaterJsonPreferNsis: true
-          args: ${{ matrix.args }}
+          args: "--features log-max-level-info"
 
   publish-release:
     permissions:


### PR DESCRIPTION
- Changed publish job args to use fixed feature flag --features log-max-level-info
- Removed dynamic args from matrix configuration in publish workflow
- Ensured consistent release publishing behavior in CI pipeline