### PR TITLE
build(ci): update tauri-action version and add debug config arg

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -291,7 +291,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build nightly application
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v0.5.23
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -302,6 +302,7 @@ jobs:
             🌙 **Nightly Build ${{ needs.create-nightly-release.outputs.build_date }}**
 
             ⚠️ This is a nightly build and may contain unstable features.
+          args: --config src-tauri/tauri.debug.conf.json
 
   publish-nightly:
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -169,7 +169,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build application
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v0.5.23
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
@@ -178,7 +178,7 @@ jobs:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           releaseBody: ${{ needs.create-release.outputs.changelog }}
           updaterJsonPreferNsis: true
-          args: "--features log-max-level-info"
+          args: --features log-max-level-info
 
   publish-release:
     permissions:


### PR DESCRIPTION
- Upgrade tauri-action from v0 to v0.5.23 in nightly and publish workflows
- Add --config src-tauri/tauri.debug.conf.json argument to nightly build step
- Fix formatting of args in publish workflow build step to remove quotes