### PR TITLE
fix(i18n): use static import for en-US in fetchDictionary

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -17,6 +17,10 @@ export const LANGUAGES = {
 } as const satisfies Record<Locale, string>;
 
 export async function fetchDictionary(locale: Locale): Promise<Dictionary> {
+  if (locale === "en-US") {
+    return i18n.flatten(enUS.dict);
+  }
+
   const dict: RawDictionary = (await import(`../i18n/${locale}.ts`)).dict;
   return i18n.flatten(dict);
 }


### PR DESCRIPTION
The en-US dictionary was both statically imported at the top of the module and dynamically imported when the locale matched. This caused a Vite warning about static and dynamic imports conflicting. Now fetchDictionary returns the already imported dict for the default locale, eliminating the warning while keeping code splitting for other languages.