### PR TITLE
feat(i18n): persist locale selection and update document language

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,7 +1,7 @@
 import * as i18n from "@solid-primitives/i18n";
 
 import * as enUS from "./en-US";
-import { createResource, createSignal } from "solid-js";
+import { createEffect, createResource, createSignal } from "solid-js";
 
 export type Locale = "en-US" | "zh-CN" | "ja-JP" | "zh-HK" | "zh-TW" | "ko-KR";
 export type RawDictionary = typeof enUS.dict;
@@ -44,5 +44,10 @@ const [dict] = createResource(locale, fetchDictionary, {
 });
 
 export const t = i18n.translator(dict, i18n.resolveTemplate);
+
+createEffect(() => {
+  localStorage.setItem("locale", locale());
+  document.documentElement.lang = locale();
+});
 
 export { locale, setLocale };


### PR DESCRIPTION
attribute

- Import `createEffect` to reactively sync locale changes
- Save selected locale to localStorage for persistence across sessions
- Set `document.documentElement.lang` to reflect current locale for accessibility and styling