### PR TITLE
feat(theme): disable UI interactions during theme download

### DIFF
--- a/src/layout/sidebar/AppSidebar.tsx
+++ b/src/layout/sidebar/AppSidebar.tsx
@@ -24,6 +24,7 @@ import { type ThemeItem, themes } from "~/themes";
 
 import { route, navigate } from "~/router";
 import { t } from "~/i18n";
+import { clsx } from "~/utils";
 
 const [imageHeights, setImageHeights] = createStore<Record<string, number>>({});
 
@@ -43,7 +44,12 @@ export const AppSidebar = () => {
       collapsible="none"
       class="[--sidebar-width:--spacing(24)] flex sticky items-center bg-neutral-200 dark:bg-transparent pt-3 h-screen"
     >
-      <SidebarContent class="overflow-x-hidden scrollbar">
+      <SidebarContent
+        class={clsx(
+          "overflow-x-hidden",
+          !theme.downloadingTheme() ? "scrollbar" : "overflow-y-hidden",
+        )}
+      >
         <SidebarMenu class="gap-2 mx-1.5">
           <For each={themes}>
             {(item, index) => (
@@ -54,7 +60,7 @@ export const AppSidebar = () => {
                   active={activeThemeID() === item.id}
                   applied={theme.appliedThemeID() === item.id}
                   github_mirror_template={config()?.github_mirror_template}
-                  // disabled={disabled()}
+                  disabled={theme.downloadingTheme()}
                 />
               </Show>
             )}
@@ -86,6 +92,7 @@ export const AppSidebar = () => {
               <TooltipTrigger>
                 <SidebarMenuButton
                   onClick={() => navigate({ path: "settings" })}
+                  disabled={theme.downloadingTheme()}
                 >
                   <Settings />
                 </SidebarMenuButton>

--- a/src/layout/theme/Actions.tsx
+++ b/src/layout/theme/Actions.tsx
@@ -49,6 +49,11 @@ const ThemeActions = (props: ThemeActionsProps) => {
     }
   };
 
+  const handleDownload = () => {
+    setDowloadingID(props.currentThemeID);
+    theme.setDownloadingTheme(true);
+  };
+
   createEffect(async () => {
     await checkThemeExists();
   });
@@ -65,14 +70,12 @@ const ThemeActions = (props: ThemeActionsProps) => {
               onFinished={() => {
                 setDowloadingID();
                 checkThemeExists();
+                theme.setDownloadingTheme(false);
               }}
             />
           }
         >
-          <Button
-            onClick={() => setDowloadingID(props.currentThemeID)}
-            disabled={!!dowloadingID()}
-          >
+          <Button onClick={handleDownload} disabled={!!dowloadingID()}>
             {t("theme.button.download")}
           </Button>
         </Show>

--- a/src/layout/theme/Theme.tsx
+++ b/src/layout/theme/Theme.tsx
@@ -15,7 +15,7 @@ import { Select } from "~/components/select";
 
 import { generateGitHubThumbnailMirrorUrl } from "~/utils/proxy";
 
-import { useConfig, useMonitor } from "~/contexts";
+import { useConfig, useMonitor, useTheme } from "~/contexts";
 import { type ThemeID, themes } from "~/themes";
 import { clsx } from "~/utils";
 import ThemeActions from "./Actions";
@@ -32,6 +32,7 @@ export const Theme = (props: ThemeProps) => {
     handleChange: handleMonitorChange,
     id: monitorID,
   } = useMonitor();
+  const { downloadingTheme } = useTheme();
 
   let aspectRatioRef: HTMLDivElement | undefined;
 
@@ -61,6 +62,7 @@ export const Theme = (props: ThemeProps) => {
           options={monitors()}
           value={monitorID()}
           onChange={handleMonitorChange}
+          disabled={downloadingTheme()}
         />
       </div>
 


### PR DESCRIPTION
- Disable theme items and settings button while downloading
- Hide scrollbar and disable monitor selection during download
- Add global `downloadingTheme` state to manage UI blocking
- Refactor download handler to set/reset downloading state