### PR TITLE
refactor: replace custom error SVG with solid-icons close circle

### DIFF
--- a/src/components/toast/components/Assets.tsx
+++ b/src/components/toast/components/Assets.tsx
@@ -1,5 +1,6 @@
 import { For, type JSX, type Component } from "solid-js";
 import type { ToastTypes } from "../types";
+import { AiFillCloseCircle } from "solid-icons/ai";
 
 // ─── Icon lookup ───────────────────────────────────────────────────────────────
 export function getAsset(type: ToastTypes): JSX.Element {
@@ -89,18 +90,5 @@ const InfoIcon: Component = () => (
 );
 
 const ErrorIcon: Component = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 20 20"
-    fill="currentColor"
-    height="20"
-    width="20"
-  >
-    <title>Error</title>
-    <path
-      fill-rule="evenodd"
-      d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z"
-      clip-rule="evenodd"
-    />
-  </svg>
+  <AiFillCloseCircle class="text-red-600 dark:text-red-800" size="18" />
 );


### PR DESCRIPTION
- Import `AiFillCloseCircle` from solid-icons/ai
- Replace manual SVG markup with the icon component
- Apply Tailwind styling for consistent coloring