### PR TITLE
refactor(styles): consolidate imports and migrate scrollbar to CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,7 @@
 @import "tailwindcss";
 
 /* Neut built-in styles (from animate.css and toast.css) */
-@import "./styles/animate.css";
-@import "./styles/toast.css";
-@import "./styles/i18n.css";
+@import "./styles/index.css";
 
 html,
 body {
@@ -18,24 +16,52 @@ body {
     -ms-user-select: none;
 }
 
-.scrollbar {
-    &::-webkit-scrollbar {
-        @apply h-1.5 w-1.5;
+@layer base {
+    :root {
+        --scrollbar-thumb: theme("colors.neutral.400");
+        --scrollbar-thumb-active: theme("colors.neutral.600");
     }
 
-    &::-webkit-scrollbar-track {
-        @apply rounded-full bg-transparent;
+    @media (prefers-color-scheme: dark) {
+        :root {
+            --scrollbar-thumb: theme("colors.neutral.600");
+            --scrollbar-thumb-active: theme("colors.neutral.400");
+        }
+    }
+}
+
+@layer utilities {
+    .scrollbar {
+        &::-webkit-scrollbar {
+            @apply h-1.5 w-1.5;
+        }
+
+        &::-webkit-scrollbar-track {
+            @apply rounded-full bg-transparent;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            @apply rounded-full bg-neutral-400 transition-all duration-200;
+        }
+
+        &::-webkit-scrollbar-thumb:hover {
+            @apply bg-neutral-500;
+        }
+
+        &::-webkit-scrollbar-thumb:active {
+            @apply bg-neutral-600 dark:bg-neutral-400;
+        }
     }
 
-    &::-webkit-scrollbar-thumb {
-        @apply rounded-full bg-neutral-400 dark:bg-neutral-600 transition-all duration-200;
-    }
+    @variant dark {
+        .scrollbar {
+            &::-webkit-scrollbar-thumb {
+                @apply bg-neutral-600;
+            }
 
-    &::-webkit-scrollbar-thumb:hover {
-        @apply bg-neutral-500;
-    }
-
-    &::-webkit-scrollbar-thumb:active {
-        @apply bg-neutral-600 dark:bg-neutral-400;
+            &::-webkit-scrollbar-thumb:active {
+                @apply bg-neutral-400;
+            }
+        }
     }
 }


### PR DESCRIPTION
layers

- Replace separate animate.css, toast.css, i18n.css imports with single index.css
- Refactor scrollbar styles using @layer base for CSS custom properties (light/dark thumb colors)
- Move scrollbar rules to @layer utilities with @variant dark for cleaner dark mode handling