### PR TITLE
feat(ui): add skeleton loading placeholders for theme images

### DIFF
--- a/src/layout/sidebar/AppSidebar.tsx
+++ b/src/layout/sidebar/AppSidebar.tsx
@@ -25,6 +25,7 @@ import { type ThemeItem, themes } from "~/themes";
 import { route, navigate } from "~/router";
 import { t } from "~/i18n";
 import { clsx } from "~/utils";
+import { Skeleton } from "~/components/skeleton";
 
 const [imageHeights, setImageHeights] = createStore<Record<string, number>>({});
 
@@ -142,6 +143,7 @@ const ThemeMenuItem = (
                   setImageHeights(props.id, height);
                 }
               }}
+              skeleton={<Skeleton class="absolute w-15 h-15" />}
             />
 
             <Show when={props.applied}>

--- a/src/layout/theme/Theme.tsx
+++ b/src/layout/theme/Theme.tsx
@@ -20,6 +20,7 @@ import { type ThemeID, themes } from "~/themes";
 import { clsx } from "~/utils";
 import ThemeActions from "./Actions";
 import { t } from "~/i18n";
+import { Skeleton } from "~/components/skeleton";
 
 interface ThemeProps {
   id: ThemeID;
@@ -77,7 +78,7 @@ export const Theme = (props: ThemeProps) => {
           <CarouselContent>
             <For each={images()}>
               {(src, index) => (
-                <CarouselItem>
+                <CarouselItem class="min-w-108">
                   <AspectRatio
                     ref={aspectRatioRef}
                     ratio={1}
@@ -100,6 +101,7 @@ export const Theme = (props: ThemeProps) => {
                           aspectRatioRef!.getBoundingClientRect().top;
                         setNameTop(top - aspectRatioTop + 8);
                       }}
+                      skeleton={<Skeleton class="absolute w-108 h-108" />}
                     />
                   </AspectRatio>
                 </CarouselItem>


### PR DESCRIPTION
- Import `Skeleton` component in `AppSidebar` and `Theme`
- Add `skeleton` prop to `Image` components in theme menu and carousel
- Adjust `CarouselItem` min-width to accommodate skeleton dimensions