### PR TITLE
fix(sidebar): restore scrollbar by moving overflow handling to SidebarMenu

### DIFF
--- a/src/layout/sidebar/AppSidebar.tsx
+++ b/src/layout/sidebar/AppSidebar.tsx
@@ -45,13 +45,13 @@ export const AppSidebar = () => {
       collapsible="none"
       class="[--sidebar-width:--spacing(24)] flex sticky items-center bg-neutral-200 dark:bg-transparent pt-3 h-screen"
     >
-      <SidebarContent
-        class={clsx(
-          "overflow-x-hidden",
-          !theme.downloadingTheme() ? "scrollbar" : "overflow-y-hidden",
-        )}
-      >
-        <SidebarMenu class="gap-2 mx-1.5">
+      <SidebarContent class="overflow-hidden">
+        <SidebarMenu
+          class={clsx(
+            "gap-2 mr-1 overflow-x-hidden overflow-y-auto",
+            !theme.downloadingTheme() ? "scrollbar" : "overflow-y-hidden",
+          )}
+        >
           <For each={themes}>
             {(item, index) => (
               <Show when={config.state === "ready"} fallback={<Spinner />}>


### PR DESCRIPTION
SidebarContent has a global `no-scrollbar` style (scrollbar-width: none) that
cannot be overridden via its `class` prop. This prevented the scrollbar from
appearing even when the conditional `scrollbar` class was applied.

Move the scrollbar-related classes (`overflow-x-hidden`, `overflow-y-auto`,
conditional `scrollbar`) from SidebarContent to SidebarMenu, and set SidebarContent to `overflow-hidden` to delegate scrolling to the inner menu.