### PR TITLE
feat: add socks5 proxy

### DIFF
--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -113,10 +113,17 @@ impl MonitorSpecificWallpapers {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(untagged)]
+pub enum Network {
+    GitHubMirrorTemplate(String),
+    Socks5 { host: String, port: u16 },
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
-    github_mirror_template: Option<String>,
+    network: Option<Network>,
 
     #[serde(default = "default_image_format")]
     image_format: ImageFormat,
@@ -230,6 +237,11 @@ impl Config {
         &self.themes_directory
     }
 
+    /// Returns the network configuration
+    pub fn network(&self) -> Option<&Network> {
+        self.network.as_ref()
+    }
+
     /// Creates a new Config with a different themes directory
     pub fn with_themes_directory(&self, themes_directory: &Path) -> Config {
         let mut config = self.clone();
@@ -266,53 +278,13 @@ impl Config {
     pub fn monitor_specific_wallpapers(&self) -> &MonitorSpecificWallpapers {
         &self.monitor_specific_wallpapers
     }
-
-    /// Resolves a GitHub asset URL to a mirrored URL if a mirror template is configured
-    ///
-    /// This method transforms GitHub release URLs using the configured mirror template,
-    /// replacing placeholders like `<owner>`, `<repo>`, `<version>`, and `<asset>`.
-    pub fn resolve_github_mirror_url(&self, github_url: &str) -> String {
-        self.github_mirror_template
-            .as_ref()
-            .and_then(|v| if v.is_empty() { None } else { Some(v.as_str()) })
-            .and_then(|template| {
-                // Parse GitHub URL: https://github.com/{owner}/{repo}/releases/download/{version}/{asset}
-                let prefix = "https://github.com/";
-                if !github_url.starts_with(prefix) {
-                    return None;
-                }
-
-                let remaining = &github_url[prefix.len()..];
-                let parts: Vec<&str> = remaining.split('/').collect();
-
-                // Expected format: {owner}/{repo}/releases/download/{version}/{asset}
-                if parts.len() >= 5 && parts[2] == "releases" && parts[3] == "download" {
-                    let owner = parts[0];
-                    let repo = parts[1];
-                    let version = parts[4];
-                    // Asset might contain slashes, so join the remaining parts
-                    let asset = parts[5..].join("/");
-
-                    Some(
-                        template
-                            .replace("<owner>", owner)
-                            .replace("<repo>", repo)
-                            .replace("<version>", version)
-                            .replace("<asset>", &asset),
-                    )
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_else(|| github_url.to_owned())
-    }
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             image_format: Default::default(),
-            github_mirror_template: Default::default(),
+            network: Default::default(),
             position_source: Default::default(),
             auto_detect_color_scheme: default_auto_detect_color_scheme(),
             themes_directory: default_themes_directory(),
@@ -327,6 +299,70 @@ impl Default for Config {
             // FIXME: This default value is a rough estimate; a more precise algorithm should
             // be used to calculate the time interval required for each 0.1 degree change.
             interval: DEFAULT_INTERVAL_SECONDS,
+        }
+    }
+}
+
+/// Intermediate deserialization struct for backward compatibility with legacy configuration files.
+///
+/// The `github_mirror_template` field was deprecated in 0.2.0 and will be removed in 0.3.0.
+/// At that time, this struct should also be removed, and the standard `Deserialize` derivation of `Config` should be restored.
+#[derive(Debug, Deserialize)]
+pub struct RawConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    github_mirror_template: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    network: Option<Network>,
+
+    #[serde(default = "default_image_format")]
+    image_format: ImageFormat,
+
+    #[serde(alias = "coordinate_source", default = "default_position_source")]
+    position_source: PositionSource,
+
+    #[serde(
+        alias = "auto_detect_color_mode",
+        default = "default_auto_detect_color_scheme"
+    )]
+    auto_detect_color_scheme: bool,
+
+    #[serde(default = "default_lock_screen_wallpaper_enabled")]
+    lock_screen_wallpaper_enabled: bool,
+
+    #[serde(default = "default_themes_directory")]
+    themes_directory: PathBuf,
+
+    /// Wallpapers specific to each monitor, using monitor ID as key
+    #[serde(default = "default_monitor_specific_wallpapers")]
+    monitor_specific_wallpapers: MonitorSpecificWallpapers,
+
+    /// Time interval for detecting solar altitude angle and azimuth angle
+    /// Measured in seconds, range: `[MIN_INTERVAL_SECONDS, MAX_INTERVAL_SECONDS]`
+    #[serde(
+        default = "default_interval",
+        deserialize_with = "deserialize_interval"
+    )]
+    interval: u16,
+}
+
+impl From<RawConfig> for Config {
+    fn from(raw: RawConfig) -> Self {
+        // Migrate github_mirror_template
+        let network = raw.network.or_else(|| {
+            raw.github_mirror_template
+                .map(Network::GitHubMirrorTemplate)
+        });
+
+        Config {
+            network,
+            image_format: raw.image_format,
+            position_source: raw.position_source,
+            auto_detect_color_scheme: raw.auto_detect_color_scheme,
+            lock_screen_wallpaper_enabled: raw.lock_screen_wallpaper_enabled,
+            themes_directory: raw.themes_directory,
+            monitor_specific_wallpapers: raw.monitor_specific_wallpapers,
+            interval: raw.interval,
         }
     }
 }

--- a/daemon/src/infrastructure/filesystem/config_manager.rs
+++ b/daemon/src/infrastructure/filesystem/config_manager.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{
-    config::Config,
+    config::{Config, RawConfig},
     error::{ConfigError, DwallResult},
     lazy::DWALL_CONFIG_DIR,
 };
@@ -84,10 +84,11 @@ impl ConfigManager {
         self.last_modified = Some(metadata.modified()?);
 
         let content = fs::read_to_string(&self.config_path)?;
-        let config: Config = toml::from_str(&content).map_err(|e| {
+        let raw_config: RawConfig = toml::from_str(&content).map_err(|e| {
             error!(error = %e, "Failed to parse configuration");
             ConfigError::Deserialization(e)
         })?;
+        let config = Config::from(raw_config);
 
         config.validate()?;
         info!("Configuration loaded successfully");

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri = { version = "2", default-features = false, features = [
 ] }
 dwall = { version = "0", path = "../daemon" }
 
-reqwest = { version = "0", default-features = false, features = [] }
+reqwest = { version = "0", default-features = false, features = ["socks"] }
 zip = { version = "8", default-features = false, features = ["deflate"] }
 open = { version = "5", default-features = false }
 tokio = { version = "1", default-features = false, features = ["macros"] }

--- a/src-tauri/src/app/commands.rs
+++ b/src-tauri/src/app/commands.rs
@@ -9,21 +9,21 @@ use std::{
 };
 
 use dwall::{
-    ColorScheme, DWALL_CONFIG_DIR, DWALL_LOG_DIR, DisplayMonitor, config::Config,
+    ColorScheme, DWALL_CONFIG_DIR, DWALL_LOG_DIR, DisplayMonitor,
     domain::geography::check_location_permission, read_config_file as dwall_read_config,
     write_config_file as dwall_write_config,
 };
 use tauri::{AppHandle, Manager, WebviewWindow};
 
 use crate::{
-    domain::{monitor::get_monitors, theme::validate_solar_theme},
+    domain::{monitor::get_monitors, settings::Config, theme::validate_solar_theme},
     error::DwallSettingsResult,
     infrastructure::{
         filesystem::move_themes_directory, network::download::ThemeDownloader,
         process::kill_daemon, registry::AutoStartManager, window::set_window_color_mode,
     },
     services::{
-        cache::{clear_thumbnail_cache, get_or_save_cached_thumbnails},
+        cache::{ThumbnailCache, clear_thumbnail_cache, get_or_save_cached_thumbnails},
         download_service::download_theme_and_extract,
         theme_service::{apply_theme, get_applied_theme_id},
     },
@@ -40,12 +40,12 @@ pub fn show_window(app: AppHandle, label: &str) -> DwallSettingsResult<()> {
 }
 
 #[tauri::command]
-pub async fn read_config_file() -> DwallSettingsResult<Config> {
+pub async fn read_config_file() -> DwallSettingsResult<dwall::Config> {
     dwall_read_config().map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn write_config_file(config: Config) -> DwallSettingsResult<()> {
+pub async fn write_config_file(config: dwall::Config) -> DwallSettingsResult<()> {
     debug!(?config, "Writing config file");
     dwall_write_config(&config).map_err(Into::into)
 }
@@ -100,7 +100,7 @@ pub async fn get_applied_theme_id_cmd(monitor_id: &str) -> DwallSettingsResult<O
 }
 
 #[tauri::command]
-pub async fn apply_theme_cmd(config: Config) -> DwallSettingsResult<()> {
+pub async fn apply_theme_cmd(config: dwall::Config) -> DwallSettingsResult<()> {
     apply_theme(config).await
 }
 
@@ -123,10 +123,10 @@ pub fn enable_auto_start() -> DwallSettingsResult<()> {
 pub async fn download_theme_cmd<R: tauri::Runtime>(
     window: tauri::WebviewWindow<R>,
     downloader: tauri::State<'_, ThemeDownloader>,
-    config: Config,
+    config: dwall::Config,
     theme_id: &str,
 ) -> DwallSettingsResult<()> {
-    download_theme_and_extract(window, downloader, config, theme_id).await
+    download_theme_and_extract(window, downloader, Config::new(config), theme_id).await
 }
 
 #[tauri::command]
@@ -145,7 +145,7 @@ pub fn request_location_permission() -> DwallSettingsResult<()> {
 
 #[tauri::command]
 pub async fn move_themes_directory_cmd(
-    config: Config,
+    config: dwall::Config,
     dir_path: PathBuf,
 ) -> DwallSettingsResult<()> {
     move_themes_directory(config, dir_path).await
@@ -158,11 +158,12 @@ pub fn kill_daemon_cmd() -> DwallSettingsResult<Option<u32>> {
 
 #[tauri::command]
 pub async fn get_or_save_cached_thumbnails_cmd(
+    cache: tauri::State<'_, ThumbnailCache>,
     theme_id: &str,
     serial_number: u8,
     url: &str,
 ) -> DwallSettingsResult<PathBuf> {
-    get_or_save_cached_thumbnails(theme_id, serial_number, url).await
+    get_or_save_cached_thumbnails(cache.inner(), theme_id, serial_number, url).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/app/setup.rs
+++ b/src-tauri/src/app/setup.rs
@@ -1,15 +1,15 @@
-use std::{env, path::PathBuf, str::FromStr};
+use std::{env, path::PathBuf, str::FromStr, sync::Arc};
 
 use tauri::Manager;
 
 use crate::{
     DAEMON_EXE_PATH,
-    app::commands::read_config_file,
     infrastructure::{
-        network::download::ThemeDownloader, process::find_daemon_process,
+        network::{client::HttpClient, download::ThemeDownloader},
+        process::find_daemon_process,
         window::create_main_window,
     },
-    services::theme_service::launch_daemon,
+    services::{cache::ThumbnailCache, theme_service::launch_daemon},
 };
 
 pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
@@ -55,8 +55,14 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
         }
     });
 
-    let theme_downloader = ThemeDownloader::new();
+    let config = dwall::read_config_file()?;
+    let http_client = Arc::new(HttpClient::create_client(config.network())?);
+
+    let theme_downloader = ThemeDownloader::new(http_client.clone());
     app.manage(theme_downloader);
+
+    let theme_cache = ThumbnailCache::new(http_client);
+    app.manage(theme_cache);
 
     create_main_window(app.app_handle())?;
 
@@ -65,9 +71,7 @@ pub fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
     // If a theme is configured in the configuration file but the background process is not detected,
     // then run the background process when this program starts.
     tokio::spawn(async move {
-        let _ = read_config_file()
-            .await
-            .and_then(|_| find_daemon_process())
+        let _ = find_daemon_process()
             .and_then(|pid| pid.map_or_else(|| launch_daemon().map(|_| ()), |_| Ok(())));
     });
 

--- a/src-tauri/src/domain/settings.rs
+++ b/src-tauri/src/domain/settings.rs
@@ -15,3 +15,63 @@
 
 // Placeholder for settings-related business logic
 // Will be populated as we refactor the existing code
+
+use std::path::Path;
+
+use dwall::config::Network;
+
+pub struct Config {
+    inner: dwall::config::Config,
+}
+
+impl Config {
+    pub fn new(inner: dwall::config::Config) -> Self {
+        Self { inner }
+    }
+
+    /// Resolves a GitHub asset URL to a mirrored URL if a mirror template is configured
+    ///
+    /// This method transforms GitHub release URLs using the configured mirror template,
+    /// replacing placeholders like `<owner>`, `<repo>`, `<version>`, and `<asset>`.
+    pub fn resolve_github_mirror_url(&self, github_url: &str) -> String {
+        match self.inner.network() {
+            None | Some(Network::Socks5 { .. }) => github_url.to_owned(),
+            Some(Network::GitHubMirrorTemplate(template)) => {
+                if template.is_empty() {
+                    return github_url.to_owned();
+                }
+
+                // Parse GitHub URL: https://github.com/{owner}/{repo}/releases/download/{version}/{asset}
+                let prefix = "https://github.com/";
+                if !github_url.starts_with(prefix) {
+                    return github_url.to_owned();
+                }
+
+                let remaining = &github_url[prefix.len()..];
+                let parts: Vec<&str> = remaining.split('/').collect();
+
+                // Expected format: {owner}/{repo}/releases/download/{version}/{asset}
+                if parts.len() >= 5 && parts[2] == "releases" && parts[3] == "download" {
+                    let owner = parts[0];
+                    let repo = parts[1];
+                    let version = parts[4];
+                    // Asset might contain slashes, so join the remaining parts
+                    let asset = parts[5..].join("/");
+
+                    template
+                        .replace("<owner>", owner)
+                        .replace("<repo>", repo)
+                        .replace("<version>", version)
+                        .replace("<asset>", &asset)
+                } else {
+                    github_url.to_owned()
+                }
+            }
+        }
+    }
+
+    /// Returns the themes directory path
+    pub fn themes_directory(&self) -> &Path {
+        self.inner.themes_directory()
+    }
+}

--- a/src-tauri/src/infrastructure/network/client.rs
+++ b/src-tauri/src/infrastructure/network/client.rs
@@ -1,0 +1,37 @@
+use std::time::Duration;
+
+use dwall::config::Network;
+use reqwest::{Client, Proxy};
+
+use crate::error::DwallSettingsResult;
+
+/// Service for downloading files over HTTP
+#[derive(Clone)]
+pub(crate) struct HttpClient;
+
+impl HttpClient {
+    /// Create a new downloader instance
+    pub fn create_client(network: Option<&Network>) -> DwallSettingsResult<Client> {
+        let builder = reqwest::ClientBuilder::new().connect_timeout(Duration::from_secs(120));
+
+        let builder = match network {
+            Some(Network::Socks5 { host, port }) => {
+                let proxy = Proxy::all(format!("socks5h://{host}:{port}")).map_err(|e| {
+                    error!(error = ?e, "Failed to create SOCKS5 proxy: {host}:{port}");
+                    e
+                })?;
+
+                info!("Using SOCKS5 proxy: {host}:{port}");
+                builder.proxy(proxy)
+            }
+            _ => builder,
+        };
+
+        let client = builder.build().map_err(|e| {
+            error!(error = %e, "Failed to create HTTP client");
+            e
+        })?;
+
+        Ok(client)
+    }
+}

--- a/src-tauri/src/infrastructure/network/download/downloader.rs
+++ b/src-tauri/src/infrastructure/network/download/downloader.rs
@@ -3,10 +3,12 @@
 //! This module coordinates the theme download process using various components.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
-use dwall::config::Config;
+use reqwest::Client;
 use tauri::Runtime;
 
+use crate::domain::settings::Config;
 use crate::error::DwallSettingsResult;
 
 use super::file_manager::ThemeFileManager;
@@ -21,9 +23,9 @@ pub struct ThemeDownloader {
 
 impl ThemeDownloader {
     /// Create a new theme downloader
-    pub fn new() -> Self {
+    pub fn new(client: Arc<Client>) -> Self {
         Self {
-            download_service: HttpDownloadService::new(),
+            download_service: HttpDownloadService::new(client),
             task_manager: DownloadTaskManager::new(),
         }
     }

--- a/src-tauri/src/infrastructure/network/download/file_manager.rs
+++ b/src-tauri/src/infrastructure/network/download/file_manager.rs
@@ -4,10 +4,9 @@
 
 use std::path::{Path, PathBuf};
 
-use dwall::config::Config;
 use tokio::fs;
 
-use crate::error::DwallSettingsResult;
+use crate::{domain::settings::Config, error::DwallSettingsResult};
 
 /// Handles file system operations for theme management
 pub(super) struct ThemeFileManager;

--- a/src-tauri/src/infrastructure/network/download/http_service.rs
+++ b/src-tauri/src/infrastructure/network/download/http_service.rs
@@ -5,9 +5,8 @@
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::time::Duration;
 
-use reqwest::StatusCode;
+use reqwest::{Client, StatusCode};
 use tauri::Runtime;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
@@ -31,21 +30,12 @@ struct DownloadContext<'a, R: Runtime> {
 
 /// Service for downloading files over HTTP
 pub(super) struct HttpDownloadService {
-    client: reqwest::Client,
+    client: Arc<Client>,
 }
 
 impl HttpDownloadService {
     /// Create a new downloader instance
-    pub(super) fn new() -> Self {
-        let client = reqwest::ClientBuilder::new()
-            .connect_timeout(Duration::from_secs(120))
-            .build()
-            .map_err(|e| {
-                error!(error = %e, "Failed to create HTTP client");
-                e
-            })
-            .unwrap();
-
+    pub(super) fn new(client: Arc<Client>) -> Self {
         Self { client }
     }
 

--- a/src-tauri/src/infrastructure/network/mod.rs
+++ b/src-tauri/src/infrastructure/network/mod.rs
@@ -2,4 +2,5 @@
 //!
 //! This module contains network-related functionality.
 
+pub mod client;
 pub mod download;

--- a/src-tauri/src/services/cache/cache_manager.rs
+++ b/src-tauri/src/services/cache/cache_manager.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 
 use dwall::DWALL_CACHE_DIR;
+use reqwest::Client;
 use tokio::sync::{Mutex, OnceCell};
 
 use crate::error::DwallSettingsResult;
@@ -39,9 +40,17 @@ static THUMBNAIL_CACHE: LazyLock<ImageCache> =
 static CLEANUP_FLAG: OnceCell<()> = OnceCell::const_new();
 
 /// Manages the thumbnail cache system
-pub struct ThumbnailCache;
+pub struct ThumbnailCache {
+    service: HttpService,
+}
 
 impl ThumbnailCache {
+    pub fn new(client: Arc<Client>) -> Self {
+        Self {
+            service: HttpService::new(client),
+        }
+    }
+
     /// Initialize the cache system
     async fn initialize_cache(thumbnails_dir: &Path) -> CacheResult<()> {
         CLEANUP_FLAG
@@ -78,6 +87,7 @@ impl ThumbnailCache {
 
     /// Get or save a cached thumbnail
     async fn get_or_save_thumbnail(
+        &self,
         theme_id: &str,
         serial_number: u8,
         url: &str,
@@ -191,7 +201,10 @@ impl ThumbnailCache {
                 image_path = %image_path.display(),
                 "Downloading image from URL"
             );
-            let file_size = HttpService::download_image(&cache_key.url, &image_path).await?;
+            let file_size = self
+                .service
+                .download_image(&cache_key.url, &image_path)
+                .await?;
 
             Ok((image_path, file_size))
         }
@@ -223,14 +236,15 @@ impl ThumbnailCache {
     }
 }
 
-/// Get or save a cached thumbnail (Tauri command)
-#[tauri::command]
+/// Get or save a cached thumbnail
 pub async fn get_or_save_cached_thumbnails(
+    cache: &ThumbnailCache,
     theme_id: &str,
     serial_number: u8,
     url: &str,
 ) -> DwallSettingsResult<PathBuf> {
-    ThumbnailCache::get_or_save_thumbnail(theme_id, serial_number, url)
+    cache
+        .get_or_save_thumbnail(theme_id, serial_number, url)
         .await
         .map_err(Into::into)
 }

--- a/src-tauri/src/services/cache/http_service.rs
+++ b/src-tauri/src/services/cache/http_service.rs
@@ -2,11 +2,12 @@
 //!
 //! This module provides functionality for downloading thumbnail images over HTTP.
 
-use std::fs;
 use std::path::Path;
 use std::sync::LazyLock;
 use std::time::Duration;
+use std::{fs, sync::Arc};
 
+use reqwest::Client;
 use tokio::sync::Semaphore;
 use tokio::time::sleep;
 
@@ -22,20 +23,17 @@ static DOWNLOAD_SEMAPHORE: LazyLock<Semaphore> =
     LazyLock::new(|| Semaphore::new(MAX_CONCURRENT_DOWNLOADS));
 
 /// Service for downloading images over HTTP
-pub struct HttpService;
+pub(super) struct HttpService {
+    client: Arc<Client>,
+}
 
 impl HttpService {
-    /// Create HTTP client with appropriate timeouts
-    pub async fn create_http_client() -> reqwest::Result<reqwest::Client> {
-        debug!("Creating HTTP client");
-        reqwest::ClientBuilder::new()
-            .connect_timeout(Duration::from_secs(120))
-            .read_timeout(Duration::from_secs(120))
-            .build()
+    pub fn new(client: Arc<Client>) -> Self {
+        Self { client }
     }
 
     /// Download an image from a URL to a local path
-    pub async fn download_image(url: &str, image_path: &Path) -> CacheResult<u64> {
+    pub async fn download_image(&self, url: &str, image_path: &Path) -> CacheResult<u64> {
         debug!(url = url, "Downloading image");
 
         let temp_path = image_path.with_extension("temp");
@@ -60,14 +58,9 @@ impl HttpService {
             }
 
             let result = async {
-                let client = Self::create_http_client().await.map_err(|e| {
-                    error!(error = %e, "Failed to create HTTP client");
-                    CacheError::from(e)
-                })?;
-
                 trace!(url = url, "Sending HTTP GET request");
-                let response = client.get(url).send().await.map_err(|e| {
-                    error!(url = url, error = %e, "Failed to get online image");
+                let response = self.client.get(url).send().await.map_err(|e| {
+                    error!(url = url, error = ?e, "Failed to get online image");
                     CacheError::from(e)
                 })?;
 

--- a/src-tauri/src/services/cache/mod.rs
+++ b/src-tauri/src/services/cache/mod.rs
@@ -9,4 +9,6 @@ mod fs_service;
 mod http_service;
 
 // Re-export the public API
-pub use self::cache_manager::{clear_thumbnail_cache, get_or_save_cached_thumbnails};
+pub use self::cache_manager::{
+    ThumbnailCache, clear_thumbnail_cache, get_or_save_cached_thumbnails,
+};

--- a/src-tauri/src/services/download_service.rs
+++ b/src-tauri/src/services/download_service.rs
@@ -2,10 +2,10 @@
 //!
 //! This module provides high-level download functionality by coordinating with the infrastructure.
 
-use dwall::Config;
 use tauri::{Runtime, State, WebviewWindow};
 
 use crate::{
+    domain::settings::Config,
     error::DwallSettingsResult,
     infrastructure::network::download::{ProgressEmitter, ThemeDownloader, ThemeExtractor},
 };

--- a/src/components/collapsible/Collapsible/Collapsible.context.ts
+++ b/src/components/collapsible/Collapsible/Collapsible.context.ts
@@ -1,0 +1,24 @@
+import {
+  type Accessor,
+  createContext,
+  type Setter,
+  useContext,
+} from "solid-js";
+
+interface CollapsibleContextValue {
+  open: Accessor<boolean>;
+  setInternalOpen: Setter<boolean>;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export const CollapsibleContext = createContext<CollapsibleContextValue>();
+
+export const useCollapsibleContext = () => {
+  const ctx = useContext(CollapsibleContext);
+  if (!ctx) {
+    throw new Error(
+      "useCollapsibleContext must be used within a CollapsibleProvider",
+    );
+  }
+  return ctx;
+};

--- a/src/components/collapsible/Collapsible/Collapsible.tsx
+++ b/src/components/collapsible/Collapsible/Collapsible.tsx
@@ -1,0 +1,34 @@
+import { createMemo, createSignal, splitProps } from "solid-js";
+import type { CollapsibleProps } from "./Collapsible.types";
+import { CollapsibleContext } from "./Collapsible.context";
+
+export const Collapsible = (props: CollapsibleProps) => {
+  const [local, others] = splitProps(props, [
+    "defaultOpen",
+    "open",
+    "onOpenChange",
+    "children",
+  ]);
+
+  const [internalOpen, setInternalOpen] = createSignal(
+    local.defaultOpen || false,
+  );
+
+  const open = createMemo(() =>
+    local.open === undefined ? internalOpen() : local.open,
+  );
+
+  return (
+    <div data-slot="collapsible" data-open={open()} {...others}>
+      <CollapsibleContext.Provider
+        value={{
+          open,
+          setInternalOpen,
+          onOpenChange: local.onOpenChange,
+        }}
+      >
+        {local.children}
+      </CollapsibleContext.Provider>
+    </div>
+  );
+};

--- a/src/components/collapsible/Collapsible/Collapsible.types.ts
+++ b/src/components/collapsible/Collapsible/Collapsible.types.ts
@@ -1,0 +1,13 @@
+import type { BaseProps, PolymorphicProps } from "~/types";
+
+interface BaseCollapsibleProps {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export type CollapsibleProps = PolymorphicProps<
+  "div",
+  BaseProps & BaseCollapsibleProps,
+  false
+>;

--- a/src/components/collapsible/Collapsible/index.ts
+++ b/src/components/collapsible/Collapsible/index.ts
@@ -1,0 +1,2 @@
+export { Collapsible } from "./Collapsible";
+export { useCollapsibleContext } from "./Collapsible.context";

--- a/src/components/collapsible/CollapsibleContent/CollapsibleContent.tsx
+++ b/src/components/collapsible/CollapsibleContent/CollapsibleContent.tsx
@@ -1,0 +1,17 @@
+import { Show, splitProps } from "solid-js";
+import type { CollapsibleContentProps } from "./CollapsibleContent.types";
+import { useCollapsibleContext } from "../Collapsible";
+
+export const CollapsibleContent = (props: CollapsibleContentProps) => {
+  const { open } = useCollapsibleContext();
+
+  const [local, others] = splitProps(props, ["children"]);
+
+  return (
+    <Show when={open()}>
+      <div data-slot="collapsible-content" {...others}>
+        {local.children}
+      </div>
+    </Show>
+  );
+};

--- a/src/components/collapsible/CollapsibleContent/CollapsibleContent.types.ts
+++ b/src/components/collapsible/CollapsibleContent/CollapsibleContent.types.ts
@@ -1,0 +1,3 @@
+import type { BaseProps, PolymorphicProps } from "~/types";
+
+export type CollapsibleContentProps = PolymorphicProps<"div", BaseProps, false>;

--- a/src/components/collapsible/CollapsibleContent/index.ts
+++ b/src/components/collapsible/CollapsibleContent/index.ts
@@ -1,0 +1,1 @@
+export { CollapsibleContent } from "./CollapsibleContent";

--- a/src/components/collapsible/CollapsibleTrigger/CollapsibleTrigger.tsx
+++ b/src/components/collapsible/CollapsibleTrigger/CollapsibleTrigger.tsx
@@ -1,0 +1,24 @@
+import { useCollapsibleContext } from "../Collapsible";
+import type { CollapsibleTriggerProps } from "./CollapsibleTrigger.types";
+import { Button } from "~/components/button";
+
+export const CollapsibleTrigger = (props: CollapsibleTriggerProps) => {
+  const { onOpenChange, open, setInternalOpen } = useCollapsibleContext();
+
+  const handleClick = () => {
+    const next = !open();
+    setInternalOpen(next);
+    onOpenChange?.(next);
+  };
+
+  return (
+    // @ts-expect-error
+    <Button
+      {...props}
+      data-slot="collapsible-trigger"
+      data-panel-open={open()}
+      aria-expanded={open()}
+      onClick={handleClick}
+    />
+  );
+};

--- a/src/components/collapsible/CollapsibleTrigger/CollapsibleTrigger.types.ts
+++ b/src/components/collapsible/CollapsibleTrigger/CollapsibleTrigger.types.ts
@@ -1,0 +1,6 @@
+import type { ParentProps } from "solid-js";
+import type { BaseButtonProps } from "~/components/button";
+
+export type CollapsibleTriggerProps = ParentProps<
+  Omit<BaseButtonProps, "onClick">
+>;

--- a/src/components/collapsible/CollapsibleTrigger/index.ts
+++ b/src/components/collapsible/CollapsibleTrigger/index.ts
@@ -1,0 +1,1 @@
+export { CollapsibleTrigger } from "./CollapsibleTrigger";

--- a/src/components/collapsible/index.ts
+++ b/src/components/collapsible/index.ts
@@ -1,0 +1,3 @@
+export { Collapsible } from "./Collapsible";
+export { CollapsibleTrigger } from "./CollapsibleTrigger";
+export { CollapsibleContent } from "./CollapsibleContent";

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -29,6 +29,9 @@ export const dict = {
       retrieveCoordinatesInterval: "Coordinates Retrieval Interval",
       automaticallySwitchModes: "Automatically Switch to Dark or Light Mode",
       checkInterval: "Check Interval",
+      network: "Network",
+      useSocks5: "Use SOCKS5 Proxy",
+      socks5: "SOCKS5",
       githubMirrorTemplate: "Github Mirror Template",
       launchAtStartup: "Launch at Startup",
       setLockScreenWallpaperSimultaneously:
@@ -44,6 +47,8 @@ export const dict = {
         "If you do not want to automatically switch between light and dark modes, please disable this option.",
       retrieveCoordinatesInterval:
         "The interval for retrieving coordinates, in minutes, should be greater than the detection interval. If your computer is always at a fixed location, you can set it to more than 24 hours. If you frequently travel with your computer, it is recommended to set it to less than 1 hour.",
+      socks5:
+        "Only enter the SOCKS5 proxy address and port number. If you do not have a valid SOCKS5 proxy server, please use the GitHub mirror template.",
       githubMirror:
         "Github mirror template is used to accelerate downloads. In some countries and regions, due to network restrictions, accessing Github may fail, resulting in download failures. You need to set up a Github mirror template to properly load thumbnails and download themes. Click this button to view available Github mirror templates:",
       launchAtStartup:
@@ -91,6 +96,7 @@ export const dict = {
         "Failed to update check interval: \n{{ error }}",
       saveRetrieveCoordinatesIntervalFailed:
         "Failed to save retrieve coordinates interval: \n{{ error }}",
+      socks5UpdateFailed: "Failed to update socks5 settings: \n{{ error }}",
     },
   },
 

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -97,6 +97,7 @@ export const dict = {
       saveRetrieveCoordinatesIntervalFailed:
         "Failed to save retrieve coordinates interval: \n{{ error }}",
       socks5UpdateFailed: "Failed to update socks5 settings: \n{{ error }}",
+      clearNetworkFailed: "Failed to clear network settings: \n{{ error }}",
     },
   },
 

--- a/src/i18n/ja-JP.ts
+++ b/src/i18n/ja-JP.ts
@@ -31,6 +31,9 @@ export const dict: RawDictionary = {
       automaticallySwitchModes: "ダークモードまたはライトモードに自動切替",
       retrieveCoordinatesInterval: "座標取得間隔",
       checkInterval: "チェック間隔",
+      network: "ネットワーク",
+      useSocks5: "SOCKS5プロキシを使用する",
+      socks5: "SOCKS5",
       githubMirrorTemplate: "Github ミラーテンプレート",
       launchAtStartup: "起動時に起動",
       setLockScreenWallpaperSimultaneously: "ロック画面の壁紙も同時に設定",
@@ -45,6 +48,8 @@ export const dict: RawDictionary = {
         "ライト/ダークモードを自動的に切り替えたくない場合は、このオプションを無効にしてください。",
       githubMirror:
         "Githubミラーテンプレートはダウンロードを高速化するために使用されます。国や地域によってはネットワーク制限のためGithubへのアクセスに失敗し、ダウンロードが失敗することがあります。サムネイルを正しく読み込み、テーマをダウンロードするには、Githubミラーテンプレートを設定する必要があります。このボタンをクリックすると、利用可能なGithubミラーテンプレートを表示できます：",
+      socks5:
+        "SOCKS5プロキシのアドレスとポート番号のみを入力してください。有効なSOCKS5プロキシサーバーがない場合は、GitHubミラーテンプレートを使用してください。",
       launchAtStartup:
         "自動起動はバックグラウンドプロセスのみを起動し、グラフィカルプログラムは起動しません。また、メモリをあまり消費しません。",
       manuallySetCoordinates:
@@ -93,6 +98,7 @@ export const dict: RawDictionary = {
         "更新チェック間隔の更新に失敗しました：\n{{ error }}",
       saveRetrieveCoordinatesIntervalFailed:
         "座標取得間隔の保存に失敗しました：\n{{ error }}",
+      socks5UpdateFailed: "SOCKS5設定の更新に失敗しました：\n{{ error }}",
     },
   },
 

--- a/src/i18n/ja-JP.ts
+++ b/src/i18n/ja-JP.ts
@@ -99,6 +99,8 @@ export const dict: RawDictionary = {
       saveRetrieveCoordinatesIntervalFailed:
         "座標取得間隔の保存に失敗しました：\n{{ error }}",
       socks5UpdateFailed: "SOCKS5設定の更新に失敗しました：\n{{ error }}",
+      clearNetworkFailed:
+        "ネットワーク設定のクリアに失敗しました：\n{{ error }}",
     },
   },
 

--- a/src/i18n/ko-KR.ts
+++ b/src/i18n/ko-KR.ts
@@ -31,6 +31,9 @@ export const dict: RawDictionary = {
       automaticallySwitchModes: "다크 또는 라이트 모드 자동 전환",
       retrieveCoordinatesInterval: "좌표 획득 간격",
       checkInterval: "확인 간격",
+      network: "네트워크",
+      useSocks5: "SOCKS5 프록시 사용",
+      socks5: "SOCKS5",
       githubMirrorTemplate: "Github 미러 템플릿",
       launchAtStartup: "시작 시 실행",
       setLockScreenWallpaperSimultaneously: "잠금 화면 배경화면도 동시에 설정",
@@ -45,6 +48,8 @@ export const dict: RawDictionary = {
         "라이트/다크 모드를 자동으로 전환하지 않으려면 이 옵션을 비활성화하세요.",
       githubMirror:
         "Github 미러 템플릿은 다운로드를 가속화하는 데 사용됩니다. 일부 국가 및 지역에서는 네트워크 제한으로 인해 Github에 액세스하지 못해 다운로드가 실패할 수 있습니다. 썸네일을 올바르게 로드하고 테마를 다운로드하려면 Github 미러 템플릿을 설정해야 합니다. 이 버튼을 클릭하면 사용 가능한 Github 미러 템플릿을 볼 수 있습니다:",
+      socks5:
+        "SOCKS5 프록시 주소와 포트 번호만 입력하세요. 유효한 SOCKS5 프록시 서버가 없는 경우 GitHub 미러 템플릿을 사용하세요.",
       launchAtStartup:
         "자동 시작은 백그라운드 프로세스만 실행하며 그래픽 프로그램은 실행되지 않습니다. 또한 메모리를 많이 소모하지 않습니다.",
       manuallySetCoordinates:
@@ -91,6 +96,7 @@ export const dict: RawDictionary = {
         "업데이트 확인 간격 업데이트에 실패했습니다: \n{{ error }}",
       saveRetrieveCoordinatesIntervalFailed:
         "좌표 검색 간격 저장 실패:\n{{ error }}",
+      socks5UpdateFailed: "SOCKS5 설정 업데이트에 실패했습니다: \n{{ error }}",
     },
   },
 

--- a/src/i18n/ko-KR.ts
+++ b/src/i18n/ko-KR.ts
@@ -97,6 +97,7 @@ export const dict: RawDictionary = {
       saveRetrieveCoordinatesIntervalFailed:
         "좌표 검색 간격 저장 실패:\n{{ error }}",
       socks5UpdateFailed: "SOCKS5 설정 업데이트에 실패했습니다: \n{{ error }}",
+      clearNetworkFailed: "네트워크 설정 클리어 실패: \n{{ error }}",
     },
   },
 

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -30,6 +30,9 @@ export const dict: RawDictionary = {
       automaticallySwitchModes: "自动切换深色或浅色模式",
       retrieveCoordinatesInterval: "坐标获取间隔",
       checkInterval: "检查间隔",
+      network: "网络",
+      useSocks5: "使用 SOCKS5 代理",
+      socks5: "SOCKS5",
       githubMirrorTemplate: "Github 镜像模板",
       launchAtStartup: "开机自启",
       setLockScreenWallpaperSimultaneously: "同时设置锁屏壁纸",
@@ -44,6 +47,8 @@ export const dict: RawDictionary = {
         "如果您不希望自动切换浅色/深色模式，请禁用此选项。",
       githubMirror:
         "Github 镜像模板用于加速下载。在某些国家和地区，由于网络限制，访问 Github 可能会失败，导致下载失败。您需要设置 Github 镜像模板才能正常加载缩略图和下载主题。点击此按钮可查看可用的 Github 镜像模板：",
+      socks5:
+        "仅输入SOCKS5代理地址和端口号。如果你没有有效的SOCKS5代理服务器，请使用Github镜像模板。",
       launchAtStartup:
         "开机自启仅会启动后台进程，不会启动图形界面程序，且不会占用过多内存。",
       manuallySetCoordinates:
@@ -84,6 +89,7 @@ export const dict: RawDictionary = {
       checkIntervalUpdateFailed: "更新检查间隔失败：\n{{ error }}",
       saveRetrieveCoordinatesIntervalFailed:
         "保存坐标获取间隔失败：\n{{ error }}",
+      socks5UpdateFailed: "更新SOCKS5设置失败：\n{{ error }}",
     },
   },
 

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -90,6 +90,7 @@ export const dict: RawDictionary = {
       saveRetrieveCoordinatesIntervalFailed:
         "保存坐标获取间隔失败：\n{{ error }}",
       socks5UpdateFailed: "更新SOCKS5设置失败：\n{{ error }}",
+      clearNetworkFailed: "清除网络设置失败：\n{{ error }}",
     },
   },
 

--- a/src/i18n/zh-HK.ts
+++ b/src/i18n/zh-HK.ts
@@ -30,6 +30,9 @@ export const dict: RawDictionary = {
       automaticallySwitchModes: "自動切換深色或淺色模式",
       retrieveCoordinatesInterval: "座標獲取間隔",
       checkInterval: "檢查間隔",
+      network: "網絡",
+      useSocks5: "使用 SOCKS5 代理",
+      socks5: "SOCKS5",
       githubMirrorTemplate: "Github 鏡像模板",
       launchAtStartup: "開機自啟",
       setLockScreenWallpaperSimultaneously: "同時設定鎖定畫面壁紙",
@@ -44,6 +47,8 @@ export const dict: RawDictionary = {
         "如果你唔希望自動切換淺色/深色模式，請停用此選項。",
       githubMirror:
         "Github 鏡像模板用於加速下載。喺某啲國家同地區，由於網絡限制，訪問 Github 可能會失敗，導致下載失敗。你需要設定 Github 鏡像模板先可以正常載入縮圖同下載主題。撳此按鈕可查看可用嘅 Github 鏡像模板：",
+      socks5:
+        "僅需輸入SOCKS5代理地址和端口號。如果你沒有有效的SOCKS5代理伺服器，請使用GitHub鏡像模板。",
       launchAtStartup:
         "開機自啟只會啟動背景進程，唔會啟動圖形介面程式，且唔會佔用過多記憶體。",
       manuallySetCoordinates:
@@ -83,6 +88,7 @@ export const dict: RawDictionary = {
       checkIntervalUpdateFailed: "更新檢查間隔失敗：\n{{ error }}",
       saveRetrieveCoordinatesIntervalFailed:
         "儲存座標檢索間隔失敗：\n{{ error }}",
+      socks5UpdateFailed: "更新SOCKS5設定失敗：\n{{ error }}",
     },
   },
 

--- a/src/i18n/zh-HK.ts
+++ b/src/i18n/zh-HK.ts
@@ -89,6 +89,7 @@ export const dict: RawDictionary = {
       saveRetrieveCoordinatesIntervalFailed:
         "儲存座標檢索間隔失敗：\n{{ error }}",
       socks5UpdateFailed: "更新SOCKS5設定失敗：\n{{ error }}",
+      clearNetworkFailed: "清除網絡設定失敗：\n{{ error }}",
     },
   },
 

--- a/src/i18n/zh-TW.ts
+++ b/src/i18n/zh-TW.ts
@@ -30,6 +30,9 @@ export const dict: RawDictionary = {
       automaticallySwitchModes: "自動切換深色或淺色模式",
       retrieveCoordinatesInterval: "座標擷取間隔",
       checkInterval: "檢查間隔",
+      network: "網路",
+      useSocks5: "使用 SOCKS5 代理",
+      socks5: "SOCKS5",
       githubMirrorTemplate: "Github 鏡像模板",
       launchAtStartup: "開機自啟",
       setLockScreenWallpaperSimultaneously: "同時設定鎖定畫面桌布",
@@ -44,6 +47,8 @@ export const dict: RawDictionary = {
         "如果您不希望自動切換淺色/深色模式，請停用此選項。",
       githubMirror:
         "Github 鏡像模板用於加速下載。在某些國家和地區，由於網路限制，存取 Github 可能會失敗，導致下載失敗。您需要設定 Github 鏡像模板才能正常載入縮圖和下載主題。點擊此按鈕可查看可用的 Github 鏡像模板：",
+      socks5:
+        "僅需輸入SOCKS5代理位址和連接埠號。如果你沒有有效的SOCKS5代理伺服器，請使用GitHub鏡像範本。",
       launchAtStartup:
         "開機自啟只會啟動背景程序，不會啟動圖形介面程式，且不會佔用過多記憶體。",
       manuallySetCoordinates:
@@ -84,6 +89,7 @@ export const dict: RawDictionary = {
       checkIntervalUpdateFailed: "更新檢查間隔失敗：\n{{ error }}",
       saveRetrieveCoordinatesIntervalFailed:
         "儲存座標檢索間隔失敗：\n{{ error }}",
+      socks5UpdateFailed: "更新SOCKS5設定失敗：\n{{ error }}",
     },
   },
 

--- a/src/i18n/zh-TW.ts
+++ b/src/i18n/zh-TW.ts
@@ -90,6 +90,7 @@ export const dict: RawDictionary = {
       saveRetrieveCoordinatesIntervalFailed:
         "儲存座標檢索間隔失敗：\n{{ error }}",
       socks5UpdateFailed: "更新SOCKS5設定失敗：\n{{ error }}",
+      clearNetworkFailed: "清除網路設定失敗：\n{{ error }}",
     },
   },
 

--- a/src/layout/settings/Settings.tsx
+++ b/src/layout/settings/Settings.tsx
@@ -2,11 +2,11 @@ import AutoStart from "./AutoStart";
 import AutoDetectColorScheme from "./AutoDetectColorScheme";
 import CoordinateSource from "./CoordinateSource";
 import Interval from "./Interval";
-import GithubMirror from "./GithubMirror";
 import ThemesDirectory from "./ThemesDirectory";
 import LockScreenWallpaperSwitch from "./LockScreenWallpaperSwitch";
 import SettingsFooter from "./Footer";
 import Languages from "./Languages";
+import Network from "./network";
 
 export const Settings = () => {
   return (
@@ -26,7 +26,7 @@ export const Settings = () => {
 
         <ThemesDirectory />
 
-        <GithubMirror />
+        <Network />
       </div>
 
       <SettingsFooter />

--- a/src/layout/settings/network/GithubMirror.tsx
+++ b/src/layout/settings/network/GithubMirror.tsx
@@ -9,7 +9,6 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from "~/components/input-group";
-import SettingsItem from "./SettingsItem";
 
 import { writeConfigFile } from "~/commands";
 
@@ -20,11 +19,12 @@ import { useConfig } from "~/contexts";
 import { Button } from "~/components/button";
 import { Compass } from "lucide-solid";
 import { t } from "~/i18n";
+import SettingsItem from "../SettingsItem";
 
-const GithubMirror = () => {
+const GithubMirror = (props: { defaultValue?: GithubMirrorTemplate }) => {
   const { data: config, refetch: refetchConfig } = useConfig();
 
-  const [value, setValue] = createSignal(config()?.github_mirror_template);
+  const [value, setValue] = createSignal(props.defaultValue ?? "");
 
   const handleInput = (v: string) => {
     setValue(v);
@@ -34,7 +34,7 @@ const GithubMirror = () => {
     const mirrorTemplate = value();
     await writeConfigFile({
       ...config()!,
-      github_mirror_template: mirrorTemplate,
+      network: mirrorTemplate,
     });
     refetchConfig();
     toast.success(

--- a/src/layout/settings/network/Socks5.tsx
+++ b/src/layout/settings/network/Socks5.tsx
@@ -1,0 +1,68 @@
+import { createStore } from "solid-js/store";
+import { AiFillSave } from "solid-icons/ai";
+
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "~/components/input-group";
+import SettingsItem from "../SettingsItem";
+import { t } from "~/i18n";
+import { useConfig } from "~/contexts";
+import { writeConfigFile } from "~/commands";
+import { toast } from "~/components/toast";
+
+export default (props: { defaultValue?: Socks5 }) => {
+  const { data: config, refetch: refetchConfig } = useConfig();
+
+  const [value, setValue] = createStore<Socks5>(
+    props.defaultValue ?? {
+      host: "127.0.0.1",
+      port: 1080,
+    },
+  );
+
+  const onSave = async () => {
+    try {
+      await writeConfigFile({ ...config()!, network: value });
+      refetchConfig();
+    } catch (e) {
+      toast.error(
+        t("settings.message.socks5UpdateFailed", { error: String(e) }),
+      );
+    }
+  };
+
+  return (
+    <SettingsItem
+      label={t("settings.label.socks5")}
+      help={t("settings.help.socks5")}
+    >
+      <InputGroup class="max-w-54">
+        <InputGroupInput
+          value={value.host}
+          placeholder="host"
+          class="flex-3"
+          onChange={(v) => setValue("host", v)}
+        />
+        :
+        <InputGroupInput
+          type="number"
+          value={value.port}
+          placeholder="port"
+          class="flex-2"
+          onChange={(v) => setValue("port", v)}
+        />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton
+            variant="ghost"
+            size="xs"
+            onClick={onSave}
+            icon={<AiFillSave />}
+          />
+        </InputGroupAddon>
+      </InputGroup>
+    </SettingsItem>
+  );
+};

--- a/src/layout/settings/network/index.tsx
+++ b/src/layout/settings/network/index.tsx
@@ -1,0 +1,61 @@
+import { createMemo, createSignal, Show } from "solid-js";
+import { ChevronRight } from "lucide-solid";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "~/components/collapsible";
+import { Switch } from "~/components/switch";
+import { t } from "~/i18n";
+import SettingsItem from "../SettingsItem";
+import Socks5 from "./Socks5";
+import { useConfig } from "~/contexts";
+import GithubMirror from "./GithubMirror";
+
+const isSocks5 = (network?: Network) =>
+  !(network && typeof network === "string");
+
+const Network = () => {
+  const { data: config } = useConfig();
+
+  const isSocks5Value = createMemo(() => isSocks5(config()?.network));
+
+  const [useSocks5, setUseSocks5] = createSignal(isSocks5Value());
+
+  return (
+    <Collapsible>
+      <CollapsibleTrigger variant="ghost" class="w-full">
+        {t("settings.label.network")}
+        <ChevronRight class="ml-auto group-data-[panel-open=true]/button:rotate-90" />
+      </CollapsibleTrigger>
+
+      <CollapsibleContent class="flex flex-col items-start gap-2 p-2.5 pt-2 text-sm">
+        <SettingsItem label={t("settings.label.useSocks5")}>
+          <Switch
+            checked={useSocks5()}
+            onCheckedChange={(checked) => setUseSocks5(checked)}
+          />
+        </SettingsItem>
+
+        <Show
+          when={useSocks5()}
+          fallback={
+            <GithubMirror
+              defaultValue={
+                isSocks5Value() ? undefined : (config()?.network as string)
+              }
+            />
+          }
+        >
+          <Socks5
+            defaultValue={
+              isSocks5Value() ? (config()?.network as Socks5) : undefined
+            }
+          />
+        </Show>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
+export default Network;

--- a/src/layout/settings/network/index.tsx
+++ b/src/layout/settings/network/index.tsx
@@ -11,19 +11,35 @@ import SettingsItem from "../SettingsItem";
 import Socks5 from "./Socks5";
 import { useConfig } from "~/contexts";
 import GithubMirror from "./GithubMirror";
+import { writeConfigFile } from "~/commands";
+import { toast } from "~/components/toast";
 
 const isSocks5 = (network?: Network) =>
   !(network && typeof network === "string");
 
 const Network = () => {
-  const { data: config } = useConfig();
+  const { data: config, refetch: refetchConfig } = useConfig();
 
   const isSocks5Value = createMemo(() => isSocks5(config()?.network));
 
   const [useSocks5, setUseSocks5] = createSignal(isSocks5Value());
 
+  const handleClear = async () => {
+    try {
+      await writeConfigFile({ ...config()!, network: undefined });
+      refetchConfig();
+    } catch (e) {
+      toast.error(
+        t("settings.message.clearNetworkFailed", { error: String(e) }),
+      );
+    }
+  };
+
   return (
-    <Collapsible>
+    <Collapsible
+      defaultOpen={!!config()?.network}
+      onOpenChange={(open) => !open && handleClear()}
+    >
       <CollapsibleTrigger variant="ghost" class="w-full">
         {t("settings.label.network")}
         <ChevronRight class="ml-auto group-data-[panel-open=true]/button:rotate-90" />

--- a/src/layout/sidebar/AppSidebar.tsx
+++ b/src/layout/sidebar/AppSidebar.tsx
@@ -60,7 +60,11 @@ export const AppSidebar = () => {
                   index={index()}
                   active={activeThemeID() === item.id}
                   applied={theme.appliedThemeID() === item.id}
-                  github_mirror_template={config()?.github_mirror_template}
+                  github_mirror_template={
+                    config()?.network && typeof config()?.network === "string"
+                      ? (config()?.network as string)
+                      : undefined
+                  }
                   disabled={theme.downloadingTheme()}
                 />
               </Show>

--- a/src/layout/theme/Theme.tsx
+++ b/src/layout/theme/Theme.tsx
@@ -85,10 +85,15 @@ export const Theme = (props: ThemeProps) => {
                     class="flex items-center justify-center"
                   >
                     <ThemeImage
-                      src={generateGitHubThumbnailMirrorUrl(
-                        src,
-                        config()!.github_mirror_template,
-                      )}
+                      src={
+                        config()?.network &&
+                        typeof config()?.network === "string"
+                          ? generateGitHubThumbnailMirrorUrl(
+                              src,
+                              config()!.network as string,
+                            )
+                          : src
+                      }
                       class="rounded-md"
                       themeID={props.id}
                       serialNumber={index() + 1}

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -1,5 +1,14 @@
+type GithubMirrorTemplate = string;
+
+interface Socks5 {
+  host: string;
+  port: number;
+}
+
+type Network = GithubMirrorTemplate | Socks5;
+
 interface Config {
-  github_mirror_template?: string;
+  network?: Network;
   selected_theme_id?: string;
   interval: number;
   image_format: string;


### PR DESCRIPTION
Introduce RawConfig as an intermediate deserialization layer to parse TOML first,
then convert it to Config via Config::from. This allows adding new fields like
socks5 proxy without breaking existing configuration files.