### PR TITLE
refactor: move resolve_github_mirror_url to utils/helpers

### DIFF
--- a/src-tauri/src/domain/settings.rs
+++ b/src-tauri/src/domain/settings.rs
@@ -18,7 +18,7 @@
 
 use std::path::Path;
 
-use dwall::config::Network;
+use crate::utils::helpers::resolve_github_mirror_url;
 
 pub struct Config {
     inner: dwall::config::Config,
@@ -34,40 +34,7 @@ impl Config {
     /// This method transforms GitHub release URLs using the configured mirror template,
     /// replacing placeholders like `<owner>`, `<repo>`, `<version>`, and `<asset>`.
     pub fn resolve_github_mirror_url(&self, github_url: &str) -> String {
-        match self.inner.network() {
-            None | Some(Network::Socks5 { .. }) => github_url.to_owned(),
-            Some(Network::GitHubMirrorTemplate(template)) => {
-                if template.is_empty() {
-                    return github_url.to_owned();
-                }
-
-                // Parse GitHub URL: https://github.com/{owner}/{repo}/releases/download/{version}/{asset}
-                let prefix = "https://github.com/";
-                if !github_url.starts_with(prefix) {
-                    return github_url.to_owned();
-                }
-
-                let remaining = &github_url[prefix.len()..];
-                let parts: Vec<&str> = remaining.split('/').collect();
-
-                // Expected format: {owner}/{repo}/releases/download/{version}/{asset}
-                if parts.len() >= 5 && parts[2] == "releases" && parts[3] == "download" {
-                    let owner = parts[0];
-                    let repo = parts[1];
-                    let version = parts[4];
-                    // Asset might contain slashes, so join the remaining parts
-                    let asset = parts[5..].join("/");
-
-                    template
-                        .replace("<owner>", owner)
-                        .replace("<repo>", repo)
-                        .replace("<version>", version)
-                        .replace("<asset>", &asset)
-                } else {
-                    github_url.to_owned()
-                }
-            }
-        }
+        resolve_github_mirror_url(self.inner.network(), github_url)
     }
 
     /// Returns the themes directory path

--- a/src-tauri/src/utils/helpers.rs
+++ b/src-tauri/src/utils/helpers.rs
@@ -2,6 +2,8 @@
 //!
 //! This module contains various helper functions used throughout the application.
 
+use dwall::config::Network;
+
 /// Creates directories if they don't exist
 pub async fn create_dir_if_missing<P: AsRef<std::path::Path>>(path: P) -> std::io::Result<()> {
     let path = path.as_ref();
@@ -9,5 +11,43 @@ pub async fn create_dir_if_missing<P: AsRef<std::path::Path>>(path: P) -> std::i
         tokio::fs::create_dir_all(path).await
     } else {
         Ok(())
+    }
+}
+
+/// Resolves a GitHub mirror URL based on the network configuration and the given URL.
+pub fn resolve_github_mirror_url(network: Option<&Network>, github_url: &str) -> String {
+    match network {
+        None | Some(Network::Socks5 { .. }) => github_url.to_owned(),
+        Some(Network::GitHubMirrorTemplate(template)) => {
+            if template.is_empty() {
+                return github_url.to_owned();
+            }
+
+            // Parse GitHub URL: https://github.com/{owner}/{repo}/releases/download/{version}/{asset}
+            let prefix = "https://github.com/";
+            if !github_url.starts_with(prefix) {
+                return github_url.to_owned();
+            }
+
+            let remaining = &github_url[prefix.len()..];
+            let parts: Vec<&str> = remaining.split('/').collect();
+
+            // Expected format: {owner}/{repo}/releases/download/{version}/{asset}
+            if parts.len() >= 5 && parts[2] == "releases" && parts[3] == "download" {
+                let owner = parts[0];
+                let repo = parts[1];
+                let version = parts[4];
+                // Asset might contain slashes, so join the remaining parts
+                let asset = parts[5..].join("/");
+
+                template
+                    .replace("<owner>", owner)
+                    .replace("<repo>", repo)
+                    .replace("<version>", version)
+                    .replace("<asset>", &asset)
+            } else {
+                github_url.to_owned()
+            }
+        }
     }
 }


### PR DESCRIPTION
- Extract GitHub mirror URL resolution logic from `Config::resolve_github_mirror_url` into a standalone function `resolve_github_mirror_url` in `helpers.rs`
- Update `Config::resolve_github_mirror_url` to delegate to the new helper function
- Add necessary `use dwall::config::Network` import and function definition in `helpers.rs`