### PR TITLE
fix(update): handle null metadata in checkForUpdates

### DIFF
--- a/src-tauri/src/app/commands.rs
+++ b/src-tauri/src/app/commands.rs
@@ -188,7 +188,7 @@ pub async fn check_for_updates_cmd<R: Runtime>(
     webview: Webview<R>,
     network: Option<Network>,
 ) -> DwallSettingsResult<Option<Metadata>, tauri_plugin_updater::Error> {
-    debug!(network = ?network);
+    debug!(network = ?network, "Checking for updates");
 
     let url = resolve_github_mirror_url(
         network.as_ref(),

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -11,8 +11,11 @@ interface UpdateMetadata {
 }
 
 export const checkForUpdates = async (network?: Network) => {
-  const metadata = await invoke<UpdateMetadata>("check_for_updates_cmd", {
-    network,
-  });
-  return new Update(metadata);
+  const metadata = await invoke<UpdateMetadata | null>(
+    "check_for_updates_cmd",
+    {
+      network,
+    },
+  );
+  return metadata ? new Update(metadata) : undefined;
 };


### PR DESCRIPTION
- Updated `invoke` type parameter to `UpdateMetadata | null`
- Added conditional check to instantiate `Update` only when metadata is present
- Return `undefined` instead of proceeding when the command returns null