### PR TITLE
fix: CSP to allow third-party styles and web fonts

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
   },
   "app": {
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost",
+      "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost; style-src-elem 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com",
       "assetProtocol": {
         "enable": true,
         "scope": ["$CACHE/com.thep0y.dwall/**"]


### PR DESCRIPTION
- Add style-src-elem 'self' https://fonts.googleapis.com
- Add font-src https://fonts.gstatic.com
- This resolves the issue of blocked external style sheets and web fonts