### PR TITLE
feat(update): show different dialog title when download completed

### DIFF
--- a/src/components/Update/index.tsx
+++ b/src/components/Update/index.tsx
@@ -106,9 +106,14 @@ const Updater = (props: ParentProps) => {
       <DialogContent>
         <DialogHeader>
           <DialogTitle>
-            {t("update.title.downloadingNewVersion", {
-              version: update()!.version,
-            })}
+            {t(
+              percentage() < 100
+                ? "update.title.downloadingNewVersion"
+                : "update.title.newVersionDownloaded",
+              {
+                version: update()!.version,
+              },
+            )}
           </DialogTitle>
         </DialogHeader>
 

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -140,6 +140,7 @@ export const dict = {
     },
     title: {
       downloadingNewVersion: "Downloading New Version {{ version }}",
+      newVersionDownloaded: "New Version {{version}} Downloaded",
     },
     message: {
       updateFailed: "Failed to update: \n{{ error }}",

--- a/src/i18n/ja-JP.ts
+++ b/src/i18n/ja-JP.ts
@@ -143,6 +143,7 @@ export const dict: RawDictionary = {
     },
     title: {
       downloadingNewVersion: "新しいバージョン {{ version }} をダウンロード中",
+      newVersionDownloaded: "新バージョン {{version}} ダウンロード済",
     },
     message: {
       updateFailed: "更新に失敗しました：\n{{ error }}",

--- a/src/i18n/ko-KR.ts
+++ b/src/i18n/ko-KR.ts
@@ -140,6 +140,7 @@ export const dict: RawDictionary = {
     },
     title: {
       downloadingNewVersion: "새 버전 {{ version }} 다운로드 중",
+      newVersionDownloaded: "새 버전 {{version}} 다운로드됨",
     },
     message: {
       updateFailed: "업데이트 실패: \n{{ error }}",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -132,6 +132,7 @@ export const dict: RawDictionary = {
     },
     title: {
       downloadingNewVersion: "正在下载新版本 {{ version }}",
+      newVersionDownloaded: "新版本 {{version}} 已下载",
     },
     message: {
       updateFailed: "更新失败：\n{{ error }}",

--- a/src/i18n/zh-HK.ts
+++ b/src/i18n/zh-HK.ts
@@ -131,6 +131,7 @@ export const dict: RawDictionary = {
     },
     title: {
       downloadingNewVersion: "正在下載新版本 {{ version }}",
+      newVersionDownloaded: "新版本 {{version}} 已下載",
     },
     message: {
       updateFailed: "更新失敗：\n{{ error }}",

--- a/src/i18n/zh-TW.ts
+++ b/src/i18n/zh-TW.ts
@@ -132,6 +132,7 @@ export const dict: RawDictionary = {
     },
     title: {
       downloadingNewVersion: "正在下載新版本 {{ version }}",
+      newVersionDownloaded: "新版本 {{version}} 已下載",
     },
     message: {
       updateFailed: "更新失敗：\n{{ error }}",


### PR DESCRIPTION
- Conditionally render DialogTitle based on download percentage
- Add "newVersionDownloaded" i18n key to en-US, ja-JP, ko-KR, zh-CN, zh-HK, zh-TW