### PR TITLE
fix: ensure user notification on manual update check

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -17,5 +17,5 @@ export const checkForUpdates = async (network?: Network) => {
       network,
     },
   );
-  return metadata ? new Update(metadata) : undefined;
+  return metadata ? new Update(metadata) : null;
 };

--- a/src/hooks/useUpdateManager.tsx
+++ b/src/hooks/useUpdateManager.tsx
@@ -11,7 +11,7 @@ export const useUpdateManager = () => {
     config,
     async (c) => {
       try {
-        return await checkForUpdates(c?.network);
+        return await checkForUpdates(c.network);
       } catch (e) {
         console.error(e);
         message(t("update.message.updateFailed", { error: String(e) }), {

--- a/src/layout/settings/Footer.tsx
+++ b/src/layout/settings/Footer.tsx
@@ -1,8 +1,8 @@
-import { createResource } from "solid-js";
+import { createResource, createSignal } from "solid-js";
 import { AiFillGithub } from "solid-icons/ai";
 
 import { getVersion } from "@tauri-apps/api/app";
-import { ask, message } from "@tauri-apps/plugin-dialog";
+import { message } from "@tauri-apps/plugin-dialog";
 import { open } from "@tauri-apps/plugin-shell";
 
 import { openLogDir } from "~/commands";
@@ -21,27 +21,37 @@ const SettingsFooter = () => {
   const [version] = createResource(getVersion);
   const { update: resource, recheckUpdate } = useUpdate();
 
+  const [checking, setChecking] = createSignal(false);
+
   const onOpenLogDir = async () => {
     await openLogDir();
   };
 
   const onUpdate = async () => {
-    if (!resource()) {
-      recheckUpdate();
+    setChecking(true);
+
+    try {
+      // Force recheck update to ensure `resource()` cannot be undefined
+      await recheckUpdate();
+    } finally {
+      setChecking(false);
     }
+
     const update = resource();
+
     if (!update) {
-      if (update === null) await message(t("settings.message.isLatestVersion"));
+      await message(t("settings.message.isLatestVersion"));
       return;
     }
 
-    const { currentVersion, version, body } = update;
+    const { currentVersion, version } = update;
 
-    const result = await ask(
-      `Current version ${currentVersion}, new version ${version} available.\n\nChangelog:\n\n${body}\n\nUpdate now?`,
-      "Dwall",
-    );
-    if (!result) return;
+    const msg = t("common.message.updateAvailable", {
+      version,
+      currentVersion,
+    });
+
+    message(msg, "Dwall");
   };
 
   const onOpenGithub = () => open("https://github.com/dwall-rs/dwall");
@@ -52,7 +62,7 @@ const SettingsFooter = () => {
         <Label class="font-light">{t("settings.label.version")}</Label>
         <Tooltip>
           <TooltipTrigger>
-            <Button onClick={onUpdate} variant="ghost">
+            <Button onClick={onUpdate} variant="ghost" disabled={checking()}>
               {version()}
             </Button>
           </TooltipTrigger>


### PR DESCRIPTION
- Change checkForUpdates return value from undefined to null for consistency
- Remove optional chaining on network parameter in useUpdateManager
- Add checking signal to disable button during update check
- Replace ask confirmation dialog with message notification
- Always show "latest version" message when update is unavailable