### PR TITLE
fix(settings): Prevent forced recheck when resource is already defined

### DIFF
--- a/src/layout/settings/Footer.tsx
+++ b/src/layout/settings/Footer.tsx
@@ -28,13 +28,14 @@ const SettingsFooter = () => {
   };
 
   const onUpdate = async () => {
-    setChecking(true);
-
-    try {
+    if (resource() === undefined) {
       // Force recheck update to ensure `resource()` cannot be undefined
-      await recheckUpdate();
-    } finally {
-      setChecking(false);
+      try {
+        setChecking(true);
+        await recheckUpdate();
+      } finally {
+        setChecking(false);
+      }
     }
 
     const update = resource();


### PR DESCRIPTION
- Wrap recheck update in conditional to run only when resource() is undefined
- Avoid changing resource ID after automatic update check
- Keep Update component's downloaded update reference valid for installation
- Show prompt without recheck if resource already exists