### PR TITLE
refactor: switch to schedule-based theme toggling

### DIFF
--- a/crates/dwall-settings/src/domain/theme.rs
+++ b/crates/dwall-settings/src/domain/theme.rs
@@ -5,7 +5,7 @@
 use std::io::Read;
 use std::path::Path;
 
-use dwall::SolarThemeValidator;
+use dwall::ThemeValidator;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -19,7 +19,7 @@ pub fn validate_solar_theme(
     themes_directory: &Path,
     theme_id: &str,
 ) -> Result<(), dwall::error::DwallError> {
-    SolarThemeValidator::validate_solar_theme(themes_directory, theme_id)
+    ThemeValidator::validate(themes_directory, theme_id)
 }
 
 /// Attempts to read the most recent error from the daemon log file

--- a/crates/dwall/src/core/daemon.rs
+++ b/crates/dwall/src/core/daemon.rs
@@ -2,7 +2,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use crate::{
-    DwallResult, domain::visual::theme_processor::SolarThemeProcessor,
+    DwallResult, domain::visual::theme_processor::ThemeProcessor,
     infrastructure::filesystem::config_manager::ConfigManager,
 };
 
@@ -27,7 +27,7 @@ impl DaemonApplication {
 
         loop {
             let config = self.config_manager.read_config()?;
-            let theme_processor = SolarThemeProcessor::new(&config)?;
+            let theme_processor = ThemeProcessor::new(&config)?;
 
             info!(
                 update_interval_seconds = config.interval(),
@@ -41,7 +41,7 @@ impl DaemonApplication {
     /// Runs the processor loop until config changes or max failures reached
     fn run_processor_loop(
         &mut self,
-        theme_processor: &SolarThemeProcessor,
+        theme_processor: &ThemeProcessor,
         consecutive_failure_count: &mut u8,
     ) -> DwallResult<()> {
         let update_interval = Duration::from_secs(theme_processor.update_interval().into());
@@ -52,7 +52,7 @@ impl DaemonApplication {
                 return Ok(());
             }
 
-            match theme_processor.run_single_cycle() {
+            match theme_processor.run_once() {
                 Ok(_) => {
                     *consecutive_failure_count = 0;
                 }
@@ -68,7 +68,7 @@ impl DaemonApplication {
                 }
             }
 
-            theme_processor.check_and_reload_monitor_configuration();
+            theme_processor.reload_if_monitors_changed();
 
             sleep(update_interval);
         }

--- a/crates/dwall/src/domain/time/mod.rs
+++ b/crates/dwall/src/domain/time/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod solar_calculator;
+pub(crate) mod solar_transitions;

--- a/crates/dwall/src/domain/time/solar_transitions.rs
+++ b/crates/dwall/src/domain/time/solar_transitions.rs
@@ -1,0 +1,132 @@
+use crate::{Position, utils::datetime::UtcDateTime};
+
+use super::solar_calculator::SunPosition;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PolarState {
+    Normal,
+    PolarDay,
+    PolarNight,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SolarTransitions {
+    pub sunrise: Option<UtcDateTime>,
+    pub sunset: Option<UtcDateTime>,
+    pub solar_noon: UtcDateTime,
+    pub polar_state: PolarState,
+}
+
+struct FindCrossingBrackets(
+    Option<(UtcDateTime, UtcDateTime)>,
+    Option<(UtcDateTime, UtcDateTime)>,
+);
+
+impl SolarTransitions {
+    pub fn calculate(position: &Position, day_start: UtcDateTime) -> Self {
+        let lat = position.latitude();
+        let lon = position.longitude();
+
+        let polar_state = Self::detect_polar_state(lat, lon, day_start);
+        let solar_noon = Self::find_solar_noon(lat, lon, day_start);
+
+        if polar_state != PolarState::Normal {
+            return Self {
+                sunrise: None,
+                sunset: None,
+                solar_noon,
+                polar_state,
+            };
+        }
+
+        let FindCrossingBrackets(sunrise_bracket, sunset_bracket) =
+            Self::find_crossing_brackets(lat, lon, day_start);
+
+        Self {
+            sunrise: sunrise_bracket.and_then(|(lo, hi)| Self::bisect(lat, lon, lo, hi, true)),
+            sunset: sunset_bracket.and_then(|(lo, hi)| Self::bisect(lat, lon, lo, hi, false)),
+            solar_noon,
+            polar_state,
+        }
+    }
+
+    fn detect_polar_state(lat: f64, lon: f64, day_start: UtcDateTime) -> PolarState {
+        let all_above = (0..12).all(|i| {
+            SunPosition::new(lat, lon, day_start.add_seconds_unchecked(i * 7200)).altitude() > 0.0
+        });
+        let all_below = (0..12).all(|i| {
+            SunPosition::new(lat, lon, day_start.add_seconds_unchecked(i * 7200)).altitude() < 0.0
+        });
+        match (all_above, all_below) {
+            (true, _) => PolarState::PolarDay,
+            (_, true) => PolarState::PolarNight,
+            _ => PolarState::Normal,
+        }
+    }
+
+    fn find_solar_noon(lat: f64, lon: f64, day_start: UtcDateTime) -> UtcDateTime {
+        let mut lo = day_start.add_seconds_unchecked(6 * 3600);
+        let mut hi = day_start.add_seconds_unchecked(18 * 3600);
+        for _ in 0..40 {
+            if hi.timestamp() - lo.timestamp() <= 1 {
+                break;
+            }
+            let m1 =
+                UtcDateTime::from_timestamp(lo.timestamp() + (hi.timestamp() - lo.timestamp()) / 3);
+            let m2 =
+                UtcDateTime::from_timestamp(hi.timestamp() - (hi.timestamp() - lo.timestamp()) / 3);
+            if SunPosition::new(lat, lon, m1).altitude() < SunPosition::new(lat, lon, m2).altitude()
+            {
+                lo = m1;
+            } else {
+                hi = m2;
+            }
+        }
+        UtcDateTime::from_timestamp((lo.timestamp() + hi.timestamp()) / 2)
+    }
+
+    fn find_crossing_brackets(lat: f64, lon: f64, day_start: UtcDateTime) -> FindCrossingBrackets {
+        let mut prev_t = day_start;
+        let mut prev_alt = SunPosition::new(lat, lon, prev_t).altitude();
+        let mut sunrise_bracket = None;
+        let mut sunset_bracket = None;
+
+        for i in 1..=144usize {
+            let t = day_start.add_seconds_unchecked(i as u64 * 600);
+            let alt = SunPosition::new(lat, lon, t).altitude();
+            if prev_alt < 0.0 && alt > 0.0 {
+                sunrise_bracket = Some((prev_t, t));
+            } else if prev_alt > 0.0 && alt < 0.0 {
+                sunset_bracket = Some((prev_t, t));
+            }
+            if sunrise_bracket.is_some() && sunset_bracket.is_some() {
+                break;
+            }
+            prev_alt = alt;
+            prev_t = t;
+        }
+        FindCrossingBrackets(sunrise_bracket, sunset_bracket)
+    }
+
+    fn bisect(
+        lat: f64,
+        lon: f64,
+        mut lo: UtcDateTime,
+        mut hi: UtcDateTime,
+        rising: bool,
+    ) -> Option<UtcDateTime> {
+        for _ in 0..20 {
+            if hi.timestamp() - lo.timestamp() <= 1 {
+                break;
+            }
+            let mid = UtcDateTime::from_timestamp((lo.timestamp() + hi.timestamp()) / 2);
+            let alt = SunPosition::new(lat, lon, mid).altitude();
+            if rising == (alt < 0.0) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        Some(lo)
+    }
+}

--- a/crates/dwall/src/domain/visual/color_scheme.rs
+++ b/crates/dwall/src/domain/visual/color_scheme.rs
@@ -8,33 +8,14 @@ use windows::Win32::{
 };
 
 use crate::{
-    Position, error::DwallResult, infrastructure::platform::windows::registry_client::RegistryKey,
+    domain::time::solar_transitions::{PolarState, SolarTransitions},
+    error::DwallResult,
+    infrastructure::platform::windows::registry_client::RegistryKey,
     utils::string::WideStringExt,
 };
 
-// Civil twilight angle (when sun is 6° below horizon)
-// This is the standard threshold used by macOS for theme switching
-const CIVIL_TWILIGHT_ANGLE: f64 = -6.0;
-
-// Hysteresis band to prevent frequent switching (±0.5° around threshold)
-const HYSTERESIS_BAND: f64 = 0.5;
-
-// Latitude boundary definitions
-const ARCTIC_CIRCLE_LATITUDE: f64 = 66.5; // Arctic/Antarctic circle boundary
-const HIGH_LATITUDE_BOUNDARY: f64 = 45.0; // Boundary for high latitude adjustments
-const TROPIC_BOUNDARY: f64 = 23.5; // Tropic of Cancer/Capricorn
-
-// Threshold adjustment ranges (in degrees)
-const POLAR_BASE_THRESHOLD: f64 = -8.0; // Base threshold for polar regions
-const POLAR_MAX_ADJUSTMENT: f64 = 4.0; // Maximum deepening for extreme polar latitudes (-8° to -12°)
-const HIGH_LAT_MAX_ADJUSTMENT: f64 = 3.0; // Maximum deepening for high latitudes (up to -3°)
-const TROPICAL_MAX_ADJUSTMENT: f64 = 1.5; // Maximum shallowing for tropical regions (up to +1.5°)
-
-// Astronomical twilight boundaries (for clamping)
-const MIN_THRESHOLD: f64 = -12.0; // Nautical twilight end (no longer useful for theme switching)
-const MAX_THRESHOLD: f64 = -4.5; // Just before civil twilight (still somewhat bright)
-
-#[derive(Debug, PartialEq, Deserialize, Copy, Clone)]
+/// Represents the system color scheme (light or dark theme).
+#[derive(Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum ColorScheme {
     Light,
@@ -42,6 +23,7 @@ pub enum ColorScheme {
 }
 
 impl ColorScheme {
+    /// Returns the corresponding registry value: 1 for Light, 0 for Dark.
     fn as_u32(&self) -> u32 {
         match self {
             ColorScheme::Light => 1,
@@ -49,7 +31,8 @@ impl ColorScheme {
         }
     }
 
-    fn to_le_bytes(self) -> [u8; 4] {
+    /// Converts the scheme to little-endian bytes suitable for writing to the registry.
+    fn as_le_bytes(&self) -> [u8; 4] {
         self.as_u32().to_le_bytes()
     }
 }
@@ -63,90 +46,7 @@ impl fmt::Display for ColorScheme {
     }
 }
 
-/// Dynamic threshold configuration based on location
-#[derive(Debug, Clone)]
-pub struct ThresholdConfig {
-    /// Primary switching threshold (solar altitude angle in degrees)
-    pub switch_threshold: f64,
-}
-
-impl ThresholdConfig {
-    /// Calculate threshold based on geographic location
-    pub fn from_location(position: &Position) -> Self {
-        let switch_threshold = Self::calculate_twilight_threshold(position);
-
-        Self { switch_threshold }
-    }
-
-    /// Calculate twilight threshold dynamically based on latitude
-    ///
-    /// Factors considered:
-    /// - Higher latitudes have longer twilight due to shallow sun path
-    /// - Tropical regions have short twilight due to steep sun path
-    /// - Uses cosine function to model sun path angle relative to horizon
-    ///
-    /// # Latitude Zones
-    /// - Tropical (0° to 23.5°): Steep sun path → shallower threshold (toward -4.5°)
-    /// - Mid-latitude (23.5° to 45°): Standard civil twilight (-6°)
-    /// - High latitude (45° to 66.5°): Shallow sun path → deeper threshold (toward -9°)
-    /// - Polar (>66.5°): Very shallow path → deepest threshold (-8° to -12°)
-    fn calculate_twilight_threshold(position: &Position) -> f64 {
-        let lat_rad = position.latitude().abs().to_radians();
-
-        // Base threshold (civil twilight)
-        let mut threshold = CIVIL_TWILIGHT_ANGLE;
-
-        // Calculate latitude factor using cosine
-        // cos(0°) = 1.0 (equator), cos(90°) = 0.0 (pole)
-        // This accurately reflects sun path angle relative to horizon
-        let latitude_factor = lat_rad.cos();
-
-        if position.latitude().abs() > ARCTIC_CIRCLE_LATITUDE {
-            // Arctic/Antarctic circles: very shallow sun paths
-            // Requires deeper threshold to handle polar day/night transitions
-            // Normalize extreme_factor: 0 at 66.5°N, 1 at 90°N
-            let extreme_factor =
-                (position.latitude().abs() - ARCTIC_CIRCLE_LATITUDE) / TROPIC_BOUNDARY;
-
-            // Transition from -8° to -12° (into nautical twilight range)
-            threshold = POLAR_BASE_THRESHOLD - extreme_factor * POLAR_MAX_ADJUSTMENT;
-        } else if position.latitude().abs() > HIGH_LATITUDE_BOUNDARY {
-            // High latitudes: longer twilight periods due to shallow sun angle
-            // Use latitude_factor for smooth transition based on sun path geometry
-            let adjustment = (1.0 - latitude_factor) * HIGH_LAT_MAX_ADJUSTMENT;
-            threshold = CIVIL_TWILIGHT_ANGLE - adjustment;
-        } else if position.latitude().abs() < TROPIC_BOUNDARY {
-            // Tropical regions: sun path nearly vertical, very short twilight
-            // Can use shallower threshold as transition is rapid
-            // Normalize tropical_factor: 1 at equator, 0 at tropics
-            let tropical_factor = (TROPIC_BOUNDARY - position.latitude().abs()) / TROPIC_BOUNDARY;
-            threshold = CIVIL_TWILIGHT_ANGLE + tropical_factor * TROPICAL_MAX_ADJUSTMENT;
-        }
-        // else: Mid-latitudes (23.5° to 45°) use default CIVIL_TWILIGHT_ANGLE
-
-        // Clamp to reasonable astronomical range
-        // Prevents extreme values that would be impractical for theme switching
-        threshold = threshold.clamp(MIN_THRESHOLD, MAX_THRESHOLD);
-
-        trace!(
-            threshold = threshold,
-            latitude = position.latitude(),
-            latitude_factor = latitude_factor,
-            "Calculated twilight threshold"
-        );
-
-        threshold
-    }
-
-    /// Create configuration with default values (when location is unavailable)
-    pub fn default_config() -> Self {
-        Self {
-            switch_threshold: CIVIL_TWILIGHT_ANGLE,
-        }
-    }
-}
-
-/// Color scheme manager for Windows system theme management
+/// Color scheme manager for Windows system theme management.
 pub(crate) struct ColorSchemeManager;
 
 impl ColorSchemeManager {
@@ -155,7 +55,7 @@ impl ColorSchemeManager {
     const APPS_THEME_VALUE: &str = "AppsUseLightTheme";
     const SYSTEM_THEME_VALUE: &str = "SystemUsesLightTheme";
 
-    /// Retrieve the current system color scheme from registry
+    /// Retrieve the current system color scheme from registry.
     pub(crate) fn get_current_scheme() -> DwallResult<ColorScheme> {
         info!("Retrieving current system color scheme");
         let registry_key = RegistryKey::open(Self::PERSONALIZE_KEY_PATH, KEY_QUERY_VALUE)?;
@@ -183,12 +83,12 @@ impl ColorSchemeManager {
         Ok(scheme)
     }
 
-    /// Set the system color scheme in the registry
-    pub(crate) fn set_color_scheme(scheme: ColorScheme) -> DwallResult<()> {
+    /// Set the system color scheme in the registry.
+    pub(crate) fn set_color_scheme(scheme: &ColorScheme) -> DwallResult<()> {
         info!(scheme = %scheme, "Setting system color scheme");
         let registry_key = RegistryKey::open(Self::PERSONALIZE_KEY_PATH, KEY_SET_VALUE)?;
 
-        let value = scheme.to_le_bytes();
+        let value = scheme.as_le_bytes();
 
         registry_key
             .set(Self::APPS_THEME_VALUE, REG_DWORD, &value)
@@ -211,68 +111,7 @@ impl ColorSchemeManager {
     }
 }
 
-/// Determine color scheme with hysteresis to avoid frequent switching
-///
-/// # Arguments
-/// * `altitude` - Solar apparent altitude angle in degrees (corrected for refraction)
-/// * `current_scheme` - Current color scheme to apply hysteresis
-/// * `config` - Threshold configuration based on location
-///
-/// # Returns
-/// Color scheme considering hysteresis band around the threshold
-///
-/// # Logic
-/// Uses symmetric hysteresis around a single threshold:
-/// - When Light: switches to Dark when sun drops below (threshold - hysteresis)
-/// - When Dark: switches to Light when sun rises above (threshold + hysteresis)
-/// - This creates a 1° hysteresis band (±0.5°) to prevent oscillation
-///
-/// # Example
-/// With threshold = -6° and hysteresis = 0.5°:
-/// - Light→Dark transition: altitude < -6.5°
-/// - Dark→Light transition: altitude > -5.5°
-/// - Between -6.5° and -5.5°: maintains current state
-pub(crate) fn determine_color_scheme_with_hysteresis(
-    altitude: f64,
-    current_scheme: &ColorScheme,
-    config: &ThresholdConfig,
-) -> ColorScheme {
-    trace!(
-        altitude = altitude,
-        current_scheme = %current_scheme,
-        threshold = config.switch_threshold,
-        "Determining color scheme with hysteresis"
-    );
-
-    let threshold = config.switch_threshold;
-
-    match current_scheme {
-        ColorScheme::Light => {
-            // Sunset: switch to Dark when sun drops below (threshold - hysteresis)
-            let switch_point = threshold - HYSTERESIS_BAND;
-            if altitude < switch_point {
-                trace!(switch_point, "Sun below lower bound, switching to Dark");
-                ColorScheme::Dark
-            } else {
-                trace!("Remaining in Light scheme");
-                ColorScheme::Light
-            }
-        }
-        ColorScheme::Dark => {
-            // Sunrise: switch to Light when sun rises above (threshold + hysteresis)
-            let switch_point = threshold + HYSTERESIS_BAND;
-            if altitude > switch_point {
-                trace!(switch_point, "Sun above upper bound, switching to Light");
-                ColorScheme::Light
-            } else {
-                trace!("Remaining in Dark scheme");
-                ColorScheme::Dark
-            }
-        }
-    }
-}
-
-/// Set the system color scheme, checking first if it needs to be changed
+/// Set the system color scheme, checking first if it needs to be changed.
 pub(crate) fn set_color_scheme(color_scheme: ColorScheme) -> DwallResult<()> {
     let current_color_scheme = ColorSchemeManager::get_current_scheme()?;
     if current_color_scheme == color_scheme {
@@ -281,7 +120,7 @@ pub(crate) fn set_color_scheme(color_scheme: ColorScheme) -> DwallResult<()> {
     }
 
     info!(from = %current_color_scheme, to = %color_scheme, "Changing color scheme");
-    ColorSchemeManager::set_color_scheme(color_scheme)?;
+    ColorSchemeManager::set_color_scheme(&color_scheme)?;
 
     if !verify_theme_change(&color_scheme)? {
         warn!("Theme change may not have been applied correctly");
@@ -290,16 +129,19 @@ pub(crate) fn set_color_scheme(color_scheme: ColorScheme) -> DwallResult<()> {
     Ok(())
 }
 
+/// Verify that the theme change was applied correctly by reading the registry
+/// after a short delay.
 fn verify_theme_change(expected: &ColorScheme) -> DwallResult<bool> {
     std::thread::sleep(std::time::Duration::from_millis(100));
     let actual = ColorSchemeManager::get_current_scheme()?;
     Ok(&actual == expected)
 }
 
-/// Notify the system about theme changes
+/// Notify the system about theme changes by broadcasting a settings change message.
 fn notify_theme_change() -> DwallResult<()> {
     trace!("Broadcasting theme change notifications");
 
+    // Build a null-terminated wide string for the notification parameter.
     let lparam = Vec::from_str("ImmersiveColorSet");
 
     unsafe {
@@ -316,167 +158,104 @@ fn notify_theme_change() -> DwallResult<()> {
     Ok(())
 }
 
+/// Schedule for switching between light and dark mode, similar to macOS appearance schedule.
+#[derive(Debug)]
+pub struct SwitchSchedule {
+    /// Unix timestamp when the system should switch to Dark mode.
+    to_dark_at: Option<u64>,
+    /// Unix timestamp when the system should switch to Light mode.
+    to_light_at: Option<u64>,
+}
+
+impl SwitchSchedule {
+    /// Construct from solar transitions with configurable offsets.
+    ///
+    /// `sunset_offset_secs`: seconds after sunset to switch to Dark (0 = switch at sunset).
+    /// `sunrise_offset_secs`: seconds before sunrise to switch to Light (negative = advance the switch time).
+    pub fn from_transitions(
+        transitions: &SolarTransitions,
+        sunset_offset_secs: i16,
+        sunrise_offset_secs: i16,
+    ) -> Self {
+        Self {
+            to_dark_at: transitions
+                .sunset
+                .map(|t| (t.timestamp() as i64 + sunset_offset_secs as i64).max(0) as u64),
+            to_light_at: transitions
+                .sunrise
+                .map(|t| (t.timestamp() as i64 + sunrise_offset_secs as i64).max(0) as u64),
+        }
+    }
+}
+
+/// Hysteresis duration (5 minutes) to avoid rapid toggling around transition boundaries.
+const SCHEDULE_HYSTERESIS_SECS: u64 = 300; // +/- 5 minutes
+
+/// Determine the appropriate color scheme based on the given schedule and polar state.
+///
+/// For polar day/night, the choice is immediate; for normal conditions the function
+/// respects the configured switching times and adds a hysteresis period to prevent
+/// frequent changes near the boundary.
+pub(crate) fn determine_color_scheme_by_schedule(
+    now_timestamp: u64,
+    schedule: &SwitchSchedule,
+    polar_state: PolarState,
+) -> ColorScheme {
+    match polar_state {
+        PolarState::PolarDay => return ColorScheme::Light,
+        PolarState::PolarNight => return ColorScheme::Dark,
+        PolarState::Normal => {}
+    }
+
+    match (schedule.to_light_at, schedule.to_dark_at) {
+        (Some(light), Some(dark)) => {
+            // Use the most recent transition point that has passed.
+            if light > dark {
+                // Sunrise after sunset is unusual; defensively return Light.
+                ColorScheme::Light
+            } else if now_timestamp >= dark + SCHEDULE_HYSTERESIS_SECS {
+                ColorScheme::Dark
+            } else if now_timestamp >= light + SCHEDULE_HYSTERESIS_SECS {
+                ColorScheme::Light
+            } else {
+                // Before sunrise, default to dark.
+                ColorScheme::Dark
+            }
+        }
+        (None, Some(_)) => ColorScheme::Dark, // No sunrise = polar night (handled above).
+        (Some(_), None) => ColorScheme::Light, // No sunset = polar day.
+        (None, None) => ColorScheme::Dark,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::time::solar_transitions::SolarTransitions;
+    use crate::utils::datetime::UtcDateTime;
 
-    #[test]
-    fn test_threshold_config_tropical() {
-        // Tropical region (Singapore: 1.3°N)
-        let position = Position::from_raw_position(1.3, 0., 15.);
-        let config = ThresholdConfig::from_location(&position);
-
-        // Tropical regions should have shallower threshold (closer to -4.5°)
-        assert!(config.switch_threshold > -6.0);
-        assert!(config.switch_threshold <= -4.5);
-    }
-
-    #[test]
-    fn test_threshold_config_high_latitude() {
-        // High latitude (Stockholm: 59.3°N)
-        let position = Position::from_raw_position(59.3, 0., 28.0);
-        let config = ThresholdConfig::from_location(&position);
-
-        // High latitudes should have deeper threshold
-        assert!(config.switch_threshold < -6.5);
-        assert!(config.switch_threshold >= -9.5);
-    }
-
-    #[test]
-    fn test_threshold_config_polar() {
-        // Polar region (Tromsø: 69.6°N)
-        let position = Position::from_raw_position(69.6, 0., 10.0);
-        let config = ThresholdConfig::from_location(&position);
-
-        // Polar regions should have even deeper threshold
-        assert!(config.switch_threshold <= -8.0);
-        assert!(config.switch_threshold >= -12.0);
-    }
-
-    #[test]
-    fn test_threshold_config_mid_latitude() {
-        // Mid latitude (New York: 40.7°N)
-        let position = Position::from_raw_position(40.7, 0., 10.0);
-        let config = ThresholdConfig::from_location(&position);
-
-        // Mid latitudes should stay close to civil twilight
-        assert!(config.switch_threshold >= -7.0);
-        assert!(config.switch_threshold <= -5.5);
-    }
-
-    #[test]
-    fn test_hysteresis_sunset() {
-        let config = ThresholdConfig::default_config();
-        // Default threshold is -6°, hysteresis is 0.5°
-
-        // Sunset scenario: Light → Dark
-        // Should switch when dropping below -6.5°
-        let altitude = -6.6;
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Light, &config),
-            ColorScheme::Dark
-        );
-
-        // At -6.0°, still above lower bound (-6.5°), stays Light
-        let altitude = -6.0;
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Light, &config),
-            ColorScheme::Light
-        );
-
-        // At -6.4°, just above lower bound, stays Light
-        let altitude = -6.4;
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Light, &config),
-            ColorScheme::Light
-        );
-    }
-
-    #[test]
-    fn test_hysteresis_sunrise() {
-        let config = ThresholdConfig::default_config();
-        // Default threshold is -6°, hysteresis is 0.5°
-
-        // Sunrise scenario: Dark → Light
-        // Should switch when rising above -5.5°
-        let altitude = -5.4;
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Dark, &config),
-            ColorScheme::Light
-        );
-
-        // At -6.0°, still below upper bound (-5.5°), stays Dark
-        let altitude = -6.0;
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Dark, &config),
-            ColorScheme::Dark
-        );
-
-        // At -5.6°, just below upper bound, stays Dark
-        let altitude = -5.6;
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Dark, &config),
-            ColorScheme::Dark
-        );
-    }
-
-    #[test]
-    fn test_hysteresis_band() {
-        let config = ThresholdConfig::default_config();
-
-        // Within hysteresis band (-6.5° to -5.5°), maintains current mode
-        let altitude = -6.0;
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Light, &config),
-            ColorScheme::Light
-        );
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Dark, &config),
-            ColorScheme::Dark
-        );
-    }
-
-    #[test]
-    fn test_extreme_altitudes() {
-        let config = ThresholdConfig::default_config();
-
-        // Noon: sun high in sky
-        let altitude = 60.0;
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Dark, &config),
-            ColorScheme::Light
-        );
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Light, &config),
-            ColorScheme::Light
-        );
-
-        // Midnight: sun far below horizon
-        let altitude = -45.0;
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Light, &config),
-            ColorScheme::Dark
-        );
-        assert_eq!(
-            determine_color_scheme_with_hysteresis(altitude, &ColorScheme::Dark, &config),
-            ColorScheme::Dark
-        );
-    }
-
-    #[test]
-    fn test_hysteresis_prevents_oscillation() {
-        let config = ThresholdConfig::default_config();
-
-        // Simulate small fluctuations around threshold
-        let altitudes = vec![-6.2, -6.0, -5.8, -6.0, -6.2];
-
-        let mut scheme = ColorScheme::Light;
-        for altitude in altitudes {
-            scheme = determine_color_scheme_with_hysteresis(altitude, &scheme, &config);
+    /// Helper to create a SolarTransitions from optional Unix timestamps.
+    fn solar_transitions(sunrise: Option<u64>, sunset: Option<u64>) -> SolarTransitions {
+        SolarTransitions {
+            sunrise: sunrise.map(UtcDateTime::from_timestamp),
+            sunset: sunset.map(UtcDateTime::from_timestamp),
+            solar_noon: UtcDateTime::from_timestamp(0), // arbitrary, not used by from_transitions
+            polar_state: PolarState::Normal,
         }
+    }
 
-        // Should remain stable (Light) despite fluctuations
-        assert_eq!(scheme, ColorScheme::Light);
+    /// Helper to create a SwitchSchedule with given timestamps.
+    fn schedule(light: Option<u64>, dark: Option<u64>) -> SwitchSchedule {
+        SwitchSchedule {
+            to_light_at: light,
+            to_dark_at: dark,
+        }
+    }
+
+    #[test]
+    fn test_color_scheme_as_u32() {
+        assert_eq!(ColorScheme::Light.as_u32(), 1);
+        assert_eq!(ColorScheme::Dark.as_u32(), 0);
     }
 
     #[test]
@@ -486,10 +265,127 @@ mod tests {
     }
 
     #[test]
-    fn test_color_scheme_conversion() {
-        assert_eq!(ColorScheme::Light.as_u32(), 1);
-        assert_eq!(ColorScheme::Dark.as_u32(), 0);
-        assert_eq!(ColorScheme::Light.to_le_bytes(), [1, 0, 0, 0]);
-        assert_eq!(ColorScheme::Dark.to_le_bytes(), [0, 0, 0, 0]);
+    fn test_color_scheme_to_le_bytes() {
+        assert_eq!(ColorScheme::Light.as_le_bytes(), 1u32.to_le_bytes());
+        assert_eq!(ColorScheme::Dark.as_le_bytes(), 0u32.to_le_bytes());
+    }
+
+    #[test]
+    fn test_switch_schedule_from_transitions_no_offset() {
+        let t = solar_transitions(Some(1_620_000_000), Some(1_620_060_000));
+        let schedule = SwitchSchedule::from_transitions(&t, 0, 0);
+        assert_eq!(schedule.to_light_at, Some(1_620_000_000));
+        assert_eq!(schedule.to_dark_at, Some(1_620_060_000));
+    }
+
+    #[test]
+    fn test_switch_schedule_from_transitions_with_offsets() {
+        let t = solar_transitions(Some(1000), Some(2000));
+        let schedule = SwitchSchedule::from_transitions(&t, 300, -300);
+        assert_eq!(schedule.to_dark_at, Some(2300)); // 2000 + 300
+        assert_eq!(schedule.to_light_at, Some(700)); // 1000 - 300
+    }
+
+    #[test]
+    fn test_switch_schedule_from_transitions_offset_clamp_to_zero() {
+        let t = solar_transitions(Some(10), Some(20));
+        let schedule = SwitchSchedule::from_transitions(&t, 0, -100);
+        assert_eq!(schedule.to_light_at, Some(0)); // clamped to 0
+        assert_eq!(schedule.to_dark_at, Some(20));
+    }
+
+    #[test]
+    fn test_polar_day_returns_light() {
+        let sched = schedule(Some(100), Some(200));
+        assert_eq!(
+            determine_color_scheme_by_schedule(150, &sched, PolarState::PolarDay),
+            ColorScheme::Light
+        );
+    }
+
+    #[test]
+    fn test_polar_night_returns_dark() {
+        let sched = schedule(Some(100), Some(200));
+        assert_eq!(
+            determine_color_scheme_by_schedule(150, &sched, PolarState::PolarNight),
+            ColorScheme::Dark
+        );
+    }
+
+    #[test]
+    fn test_normal_both_some_before_light_hysteresis() {
+        // Hysteresis adds 300s to both timestamps.
+        // now=150 is before light+300 (400) and dark is 200+300=500 -> default Dark.
+        assert_eq!(
+            determine_color_scheme_by_schedule(
+                150,
+                &schedule(Some(100), Some(200)),
+                PolarState::Normal
+            ),
+            ColorScheme::Dark
+        );
+    }
+
+    #[test]
+    fn test_normal_both_some_after_light_hysteresis() {
+        // now=450: >=400 but <500 -> Light.
+        assert_eq!(
+            determine_color_scheme_by_schedule(
+                450,
+                &schedule(Some(100), Some(200)),
+                PolarState::Normal
+            ),
+            ColorScheme::Light
+        );
+    }
+
+    #[test]
+    fn test_normal_both_some_after_dark_hysteresis() {
+        // now=550: >=500 -> Dark.
+        assert_eq!(
+            determine_color_scheme_by_schedule(
+                550,
+                &schedule(Some(100), Some(200)),
+                PolarState::Normal
+            ),
+            ColorScheme::Dark
+        );
+    }
+
+    #[test]
+    fn test_normal_only_dark_returns_dark() {
+        assert_eq!(
+            determine_color_scheme_by_schedule(0, &schedule(None, Some(200)), PolarState::Normal),
+            ColorScheme::Dark
+        );
+    }
+
+    #[test]
+    fn test_normal_only_light_returns_light() {
+        assert_eq!(
+            determine_color_scheme_by_schedule(0, &schedule(Some(100), None), PolarState::Normal),
+            ColorScheme::Light
+        );
+    }
+
+    #[test]
+    fn test_normal_none_returns_dark() {
+        assert_eq!(
+            determine_color_scheme_by_schedule(0, &schedule(None, None), PolarState::Normal),
+            ColorScheme::Dark
+        );
+    }
+
+    #[test]
+    fn test_normal_defense_light_greater_than_dark() {
+        // Defensive: if light > dark, return Light.
+        assert_eq!(
+            determine_color_scheme_by_schedule(
+                0,
+                &schedule(Some(300), Some(200)),
+                PolarState::Normal
+            ),
+            ColorScheme::Light
+        );
     }
 }

--- a/crates/dwall/src/domain/visual/mod.rs
+++ b/crates/dwall/src/domain/visual/mod.rs
@@ -4,4 +4,4 @@ pub(crate) mod wallpaper;
 
 // Re-export commonly used types
 pub use color_scheme::ColorScheme;
-pub use theme_processor::{SolarThemeValidator, ThemeProcessingError, apply_solar_theme};
+pub use theme_processor::{ThemeError, ThemeValidator, apply_solar_theme};

--- a/crates/dwall/src/domain/visual/theme_processor.rs
+++ b/crates/dwall/src/domain/visual/theme_processor.rs
@@ -14,46 +14,75 @@ use crate::{
     config::Config,
     domain::{
         geography::{Position, provider::GeographicPositionProvider},
-        time::solar_calculator::{SolarAngle, SunPosition},
+        time::{
+            solar_calculator::{SolarAngle, SunPosition},
+            solar_transitions::{PolarState, SolarTransitions},
+        },
         visual::color_scheme::{
-            ColorSchemeManager, ThresholdConfig, determine_color_scheme_with_hysteresis,
-            set_color_scheme,
+            SwitchSchedule, determine_color_scheme_by_schedule, set_color_scheme,
         },
     },
     infrastructure::display::wallpaper_setter::WallpaperSetter,
     utils::datetime::UtcDateTime,
 };
 
-// Constants for improved code maintainability
-const MAX_CONSECUTIVE_FAILURE_THRESHOLD: u8 = 3;
-const SOLAR_CONFIG_FILENAME: &str = "solar.json";
+const MAX_CONSECUTIVE_FAILURES: u8 = 3;
+const SOLAR_CONFIG_FILE: &str = "solar.json";
 
 /// Comprehensive error handling for solar theme-related operations
 #[derive(Debug, thiserror::Error)]
-pub enum ThemeProcessingError {
+pub enum ThemeError {
     #[error("Theme directory '{0}' does not exist")]
-    ThemeDirectoryNotFound(String),
+    DirectoryNotFound(String),
     #[error("Default theme is missing or not configured")]
     DefaultThemeMissing,
     #[error("Solar configuration file 'solar.json' is missing in theme directory")]
-    SolarConfigurationMissing,
+    SolarConfigMissing,
     #[error("Image files do not match solar configuration: expected {expected}, found {found}")]
-    ImageSolarConfigurationMismatch { expected: usize, found: usize },
+    ImageConfigMismatch { expected: usize, found: usize },
     #[error("Wallpaper image file '{path}' does not exist")]
-    WallpaperImageMissing { path: String },
+    WallpaperMissing { path: String },
     #[error("No monitor-specific wallpaper configurations found")]
-    MonitorWallpaperConfigurationMissing,
+    NoMonitorConfig,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ScheduleCacheKey {
+    date: u32, // yyyymmdd
+    // 位置精度截断到小数点后 3 位（约 111 米），
+    // 避免 GPS 抖动导致每次 tick 都重算
+    lat_i32: i32, // latitude  × 1000 as i32
+    lon_i32: i32, // longitude × 1000 as i32
+}
+
+impl ScheduleCacheKey {
+    fn from(now: UtcDateTime, position: &Position) -> Self {
+        let (y, m, d, ..) = now.ymd_hms();
+        Self {
+            date: y as u32 * 10000 + m as u8 as u32 * 100 + d as u32,
+            lat_i32: (position.latitude() * 1000.0).round() as i32,
+            lon_i32: (position.longitude() * 1000.0).round() as i32,
+        }
+    }
+}
+
+// 缓存当天的切换计划，避免每分钟重算
+struct CachedSchedule {
+    key: ScheduleCacheKey,
+    schedule: SwitchSchedule,
+    polar_state: PolarState,
 }
 
 /// Manages the lifecycle and processing of solar-based visual themes
-pub(crate) struct SolarThemeProcessor<'a> {
+pub(crate) struct ThemeProcessor<'a> {
     config: &'a Config,
-    geographic_position_provider: GeographicPositionProvider<'a>,
-    wallpaper_manager: WallpaperSetter,
+    position_provider: GeographicPositionProvider<'a>,
+    wallpaper_setter: WallpaperSetter,
+    cached_schedule: RefCell<Option<CachedSchedule>>,
 }
 
-impl<'a> SolarThemeProcessor<'a> {
-    /// Creates a new SolarThemeProcessor instance with the provided configuration
+impl<'a> ThemeProcessor<'a> {
+    /// Creates a new `ThemeProcessor` with the provided configuration
     pub(crate) fn new(config: &'a Config) -> DwallResult<Self> {
         info!(
             auto_detect_color_mode = ?config.auto_detect_color_scheme(),
@@ -62,12 +91,11 @@ impl<'a> SolarThemeProcessor<'a> {
             "Initializing solar theme processor"
         );
 
-        let wallpaper_manager = WallpaperSetter::new()?;
-
         Ok(Self {
-            geographic_position_provider: GeographicPositionProvider::new(config.position_source()),
+            position_provider: GeographicPositionProvider::new(config.position_source()),
+            wallpaper_setter: WallpaperSetter::new()?,
             config,
-            wallpaper_manager,
+            cached_schedule: RefCell::new(None),
         })
     }
 
@@ -76,668 +104,545 @@ impl<'a> SolarThemeProcessor<'a> {
         self.config.interval()
     }
 
-    /// Runs a single solar theme update cycle
+    /// Runs a single solar theme update cycle.
     ///
-    /// Returns `true` if the cycle was successful, `false` otherwise
-    pub(crate) fn run_single_cycle(&self) -> DwallResult<bool> {
-        let current_geographic_position =
-            self.geographic_position_provider.get_current_position()?;
-        let result = self.process_solar_theme_cycle(&current_geographic_position);
+    /// Returns `true` if the cycle succeeded.
+    pub(crate) fn run_once(&self) -> DwallResult<bool> {
+        let position = self.position_provider.get_current_position()?;
 
-        if let Err(error) = &result {
-            error!(error = %error, "Solar theme cycle failed");
+        let now = UtcDateTime::now();
+
+        let result = self.process_cycle(&position, now);
+
+        if let Err(ref e) = result {
+            error!(error = %e, "Solar theme cycle failed");
         }
 
         result.map(|_| true)
     }
 
-    /// Checks if monitor configuration has changed and reloads if necessary
+    /// Checks if monitor configuration has changed and reloads if necessary.
     ///
-    /// Returns `true` if monitor configuration was reloaded
-    pub(crate) fn check_and_reload_monitor_configuration(&self) -> bool {
-        let monitor_configuration_changed = self
-            .wallpaper_manager
+    /// Returns `true` if the configuration was reloaded.
+    pub(crate) fn reload_if_monitors_changed(&self) -> bool {
+        let changed = self
+            .wallpaper_setter
             .is_monitor_configuration_stale()
             .unwrap_or(false);
 
-        if monitor_configuration_changed {
-            info!("Monitor configuration change detected, refreshing and reapplying wallpapers");
-
-            if let Err(reload_error) = self.wallpaper_manager.reload_monitor_configuration() {
-                warn!(error = %reload_error, "Failed to reload monitor configuration");
-                return false;
-            }
-
-            if let Ok(current_geographic_position) =
-                self.geographic_position_provider.get_current_position()
-            {
-                if let Err(reapply_error) =
-                    self.process_solar_theme_cycle(&current_geographic_position)
-                {
-                    error!(error = %reapply_error, "Failed to reapply solar wallpapers after monitor configuration change");
-                } else {
-                    debug!(
-                        "Solar wallpapers successfully applied to updated monitor configuration"
-                    );
-                }
-            }
-
-            return true;
+        if !changed {
+            return false;
         }
 
-        false
+        info!("Monitor configuration change detected, refreshing and reapplying wallpapers");
+
+        if let Err(e) = self.wallpaper_setter.reload_monitor_configuration() {
+            warn!(error = %e, "Failed to reload monitor configuration");
+            return false;
+        }
+
+        if let Ok(position) = self.position_provider.get_current_position() {
+            if let Err(e) = self.process_cycle(&position, UtcDateTime::now()) {
+                error!(error = %e, "Failed to reapply wallpapers after monitor configuration change");
+            } else {
+                debug!("Wallpapers successfully applied to updated monitor configuration");
+            }
+        }
+
+        true
     }
 
     /// Starts a continuous loop to update wallpaper themes based on current solar position
-    pub fn start_solar_update_loop(&self) -> DwallResult<()> {
+    pub fn start_update_loop(&self) -> DwallResult<()> {
         info!(
             update_interval_seconds = self.config.interval(),
             "Starting solar-based theme update loop"
         );
 
-        let mut last_update_timestamp = UtcDateTime::now();
-        let mut consecutive_failure_count = 0;
-
-        let update_interval_duration = Duration::from_secs(self.config.interval().into());
+        let mut last_update = UtcDateTime::now();
+        let mut failure_count = 0u8;
+        let interval = Duration::from_secs(self.config.interval().into());
 
         loop {
-            let current_timestamp = UtcDateTime::now();
+            let now = UtcDateTime::now();
             debug!(
-                last_update_timestamp = %last_update_timestamp,
-                current_timestamp = %current_timestamp,
+                last_update = %last_update,
+                current = %now,
                 "Starting solar theme update cycle"
             );
 
-            // Get current geographic position and process solar theme cycle
-            let current_geographic_position =
-                self.geographic_position_provider.get_current_position()?;
-            let theme_cycle_result = self.process_solar_theme_cycle(&current_geographic_position);
+            let position = self.position_provider.get_current_position()?;
 
-            match theme_cycle_result {
+            match self.process_cycle(&position, now) {
                 Ok(_) => {
                     debug!(
-                        latitude = current_geographic_position.latitude(),
-                        longitude = current_geographic_position.longitude(),
+                        latitude = position.latitude(),
+                        longitude = position.longitude(),
                         "Solar theme cycle completed successfully"
                     );
-                    consecutive_failure_count = 0; // Reset failure counter on success
+                    failure_count = 0;
                 }
-                Err(error) => {
-                    consecutive_failure_count += 1;
+                Err(e) => {
+                    failure_count += 1;
                     error!(
-                        error = %error,
-                        consecutive_failure_count,
-                        max_failure_threshold = MAX_CONSECUTIVE_FAILURE_THRESHOLD,
+                        error = %e,
+                        failure_count,
+                        max_failures = MAX_CONSECUTIVE_FAILURES,
                         "Solar theme cycle failed"
                     );
 
-                    if consecutive_failure_count >= MAX_CONSECUTIVE_FAILURE_THRESHOLD {
+                    if failure_count >= MAX_CONSECUTIVE_FAILURES {
                         error!(
-                            consecutive_failures = consecutive_failure_count,
-                            "Maximum consecutive failures reached, terminating solar theme update loop"
+                            failure_count,
+                            "Maximum consecutive failures reached, terminating update loop"
                         );
                         break;
                     }
                 }
             }
 
-            // Check if monitor configuration has changed after processing
-            let monitor_configuration_changed = self
-                .wallpaper_manager
+            let monitors_changed = self
+                .wallpaper_setter
                 .is_monitor_configuration_stale()
                 .unwrap_or(false);
 
-            if monitor_configuration_changed {
+            if monitors_changed {
                 info!(
                     "Monitor configuration change detected, refreshing and reapplying wallpapers"
                 );
 
-                // Refresh monitor list
-                if let Err(reload_error) = self.wallpaper_manager.reload_monitor_configuration() {
-                    warn!(
-                        error = %reload_error,
-                        "Failed to reload monitor configuration after change detection"
-                    );
+                if let Err(e) = self.wallpaper_setter.reload_monitor_configuration() {
+                    warn!(error = %e, "Failed to reload monitor configuration after change detection");
                 } else {
-                    // Immediately reapply wallpaper to new monitor configuration
-                    info!("Reapplying solar wallpapers to updated monitor configuration");
-                    let reapply_result =
-                        self.process_solar_theme_cycle(&current_geographic_position);
-
-                    if let Err(reapply_error) = reapply_result {
-                        error!(
-                            error = %reapply_error,
-                            "Failed to reapply solar wallpapers after monitor configuration change"
-                        );
+                    info!("Reapplying wallpapers to updated monitor configuration");
+                    if let Err(e) = self.process_cycle(&position, now) {
+                        error!(error = %e, "Failed to reapply wallpapers after monitor configuration change");
                     } else {
-                        debug!(
-                            "Solar wallpapers successfully applied to updated monitor configuration"
-                        );
+                        debug!("Wallpapers successfully applied to updated monitor configuration");
                     }
                 }
 
-                // Skip sleep interval and continue immediately to next cycle
-                last_update_timestamp = current_timestamp;
+                last_update = now;
                 continue;
             }
 
-            // Normal flow: sleep before next update
             debug!(
-                sleep_duration_seconds = update_interval_duration.as_secs(),
+                sleep_seconds = interval.as_secs(),
                 "Waiting before next solar theme update cycle"
             );
 
-            last_update_timestamp = current_timestamp;
-            sleep(update_interval_duration);
+            last_update = now;
+            sleep(interval);
         }
 
         warn!("Solar theme update loop terminated");
         Ok(())
     }
 
-    /// Process solar theme cycle for the current geographic position
-    pub(crate) fn process_solar_theme_cycle(
-        &self,
-        geographic_position: &Position,
-    ) -> DwallResult<()> {
-        process_solar_theme_cycle(self.config, geographic_position, &self.wallpaper_manager)
+    /// Processes one solar theme cycle for the given geographic position
+    pub(crate) fn process_cycle(&self, position: &Position, now: UtcDateTime) -> DwallResult<()> {
+        self.run_theme_cycle(position, now)
+    }
+
+    /// Core cycle function: updates wallpapers for all monitors and optionally the lock screen
+    fn run_theme_cycle(&self, position: &Position, now: UtcDateTime) -> DwallResult<()> {
+        debug!(
+            auto_detect_color_mode = self.config.auto_detect_color_scheme(),
+            image_format = ?self.config.image_format(),
+            latitude = position.latitude(),
+            longitude = position.longitude(),
+            "Starting solar theme processing cycle"
+        );
+
+        let monitors = self.wallpaper_setter.list_available_monitors()?;
+        let monitor_themes = self.config.monitor_specific_wallpapers();
+        let sun = SunPosition::new(position.latitude(), position.longitude(), now);
+
+        let mut lock_screen_theme: Option<String> = None;
+        let mut success_count = 0usize;
+
+        for monitor_id in monitors.keys() {
+            let theme_id = match monitor_themes.get(monitor_id) {
+                Some(id) => id,
+                None => {
+                    debug!(
+                        monitor_id,
+                        "No theme configuration found for monitor, skipping"
+                    );
+                    continue;
+                }
+            };
+
+            info!(
+                monitor_id,
+                theme_id, "Processing solar wallpaper for monitor"
+            );
+
+            if lock_screen_theme.is_none() {
+                lock_screen_theme = Some(theme_id.to_string());
+            }
+
+            if let Err(e) = set_monitor_wallpaper(
+                self.config,
+                monitor_id,
+                theme_id,
+                &sun,
+                &self.wallpaper_setter,
+            ) {
+                error!(error = %e, monitor_id, theme_id, "Failed to update solar wallpaper for monitor");
+                continue;
+            }
+
+            success_count += 1;
+        }
+
+        if self.config.lock_screen_wallpaper_enabled()
+            && success_count > 0
+            && let Some(ref theme_id) = lock_screen_theme
+            && let Err(e) = set_lock_screen_wallpaper(self.config, theme_id, &sun)
+        {
+            warn!(
+                error = %e,
+                theme_id,
+                "Failed to apply solar wallpaper to lock screen, continuing"
+            );
+        }
+
+        if self.config.auto_detect_color_scheme() {
+            let cache_key = ScheduleCacheKey::from(now, position);
+
+            if self
+                .cached_schedule
+                .borrow()
+                .as_ref()
+                .is_none_or(|c| c.key != cache_key)
+            {
+                let day_start = now.start_of_day(); // 需要在 UtcDateTime 上实现此方法
+                let transitions = SolarTransitions::calculate(position, day_start);
+                let schedule = SwitchSchedule::from_transitions(
+                    &transitions,
+                    0,     // 日落即切 Dark
+                    -1800, // 日出前 30 分钟切 Light
+                );
+
+                *self.cached_schedule.borrow_mut() = Some(CachedSchedule {
+                    key: cache_key,
+                    schedule,
+                    polar_state: transitions.polar_state,
+                });
+            }
+
+            let borrow = self.cached_schedule.borrow();
+            let cached = borrow.as_ref().unwrap();
+
+            let target = determine_color_scheme_by_schedule(
+                now.timestamp(),
+                &cached.schedule,
+                cached.polar_state,
+            );
+
+            info!(
+                scheme = ?target,
+                altitude = sun.altitude(),
+                "Updating system color scheme based on solar position"
+            );
+            if let Err(e) = set_color_scheme(target) {
+                warn!(error = %e, "Failed to update system color scheme, continuing");
+            }
+        }
+
+        info!(
+            success_count,
+            total = monitors.len(),
+            "Solar theme processing cycle completed"
+        );
+
+        Ok(())
     }
 }
 
 /// Theme validation utilities for solar-based wallpaper themes
-pub struct SolarThemeValidator;
+pub struct ThemeValidator;
 
-impl SolarThemeValidator {
-    /// Validates if a solar theme exists and has proper configuration and image files
-    pub fn validate_solar_theme(
-        themes_directory: &Path,
-        theme_identifier: &str,
-    ) -> DwallResult<()> {
+impl ThemeValidator {
+    /// Validates that a solar theme exists and has proper configuration and image files
+    pub fn validate(themes_dir: &Path, theme_id: &str) -> DwallResult<()> {
         trace!(
-            theme_id = theme_identifier,
-            themes_directory = %themes_directory.display(),
+            theme_id,
+            themes_dir = %themes_dir.display(),
             "Starting solar theme validation"
         );
 
-        let theme_directory_path = themes_directory.join(theme_identifier);
+        let theme_dir = themes_dir.join(theme_id);
 
-        if !theme_directory_path.exists() {
+        if !theme_dir.exists() {
             warn!(
-                theme_id = theme_identifier,
-                theme_path = %theme_directory_path.display(),
+                theme_id,
+                theme_dir = %theme_dir.display(),
                 "Solar theme directory not found"
             );
-            return Err(
-                ThemeProcessingError::ThemeDirectoryNotFound(theme_identifier.to_string()).into(),
-            );
+            return Err(ThemeError::DirectoryNotFound(theme_id.to_string()).into());
         }
 
-        let solar_angle_configuration =
-            Self::load_solar_angle_configuration(&theme_directory_path)?;
-        let expected_image_indices: Vec<u8> = solar_angle_configuration
-            .iter()
-            .map(|angle| angle.index)
-            .collect();
+        let solar_angles = Self::load_solar_angles(&theme_dir)?;
+        let expected_indices: Vec<u8> = solar_angles.iter().map(|a| a.index).collect();
 
-        if !Self::validate_theme_image_files(&theme_directory_path, &expected_image_indices, "jpg")
-        {
+        if !Self::validate_images(&theme_dir, &expected_indices, "jpg") {
             warn!(
-                theme_id = theme_identifier,
-                expected_images = expected_image_indices.len(),
+                theme_id,
+                expected_images = expected_indices.len(),
                 "Solar theme image validation failed"
             );
-            return Err(ThemeProcessingError::ImageSolarConfigurationMismatch {
-                expected: expected_image_indices.len(),
-                found: 0, // We'll improve this in validate_theme_image_files
+            return Err(ThemeError::ImageConfigMismatch {
+                expected: expected_indices.len(),
+                found: 0,
             }
             .into());
         }
 
         info!(
-            theme_id = theme_identifier,
-            solar_angles_count = solar_angle_configuration.len(),
+            theme_id,
+            solar_angles_count = solar_angles.len(),
             "Solar theme validation completed successfully"
         );
         Ok(())
     }
 
-    /// Loads solar angle configuration from theme directory
-    fn load_solar_angle_configuration(theme_directory: &Path) -> DwallResult<Vec<SolarAngle>> {
-        let solar_configuration_file_path = theme_directory.join(SOLAR_CONFIG_FILENAME);
+    /// Loads solar angle configuration from a theme directory
+    fn load_solar_angles(theme_dir: &Path) -> DwallResult<Vec<SolarAngle>> {
+        let config_path = theme_dir.join(SOLAR_CONFIG_FILE);
 
-        if !solar_configuration_file_path.exists() {
+        if !config_path.exists() {
             error!(
-                solar_config_path = %solar_configuration_file_path.display(),
+                config_path = %config_path.display(),
                 "Solar configuration file 'solar.json' is missing from theme directory"
             );
-            return Err(ThemeProcessingError::SolarConfigurationMissing.into());
+            return Err(ThemeError::SolarConfigMissing.into());
         }
 
-        let solar_configuration_content = fs::read_to_string(&solar_configuration_file_path)
-            .map_err(|io_error| {
-                error!(
-                    error = %io_error,
-                    solar_config_path = %solar_configuration_file_path.display(),
-                    "Failed to read solar configuration file"
-                );
-                io_error
-            })?;
+        let content = fs::read_to_string(&config_path).map_err(|e| {
+            error!(error = %e, config_path = %config_path.display(), "Failed to read solar configuration file");
+            e
+        })?;
 
-        let solar_angle_list: Vec<SolarAngle> = serde_json::from_str(&solar_configuration_content)
-            .map_err(|json_error| {
-                error!(
-                    error = %json_error,
-                    solar_config_path = %solar_configuration_file_path.display(),
-                    "Failed to parse solar configuration JSON"
-                );
-                json_error
-            })?;
+        let angles: Vec<SolarAngle> = serde_json::from_str(&content).map_err(|e| {
+            error!(error = %e, config_path = %config_path.display(), "Failed to parse solar configuration JSON");
+            e
+        })?;
 
         debug!(
-            solar_angles_count = solar_angle_list.len(),
-            solar_config_path = %solar_configuration_file_path.display(),
+            count = angles.len(),
+            config_path = %config_path.display(),
             "Successfully loaded solar angle configuration"
         );
-        Ok(solar_angle_list)
+        Ok(angles)
     }
 
     /// Validates that all required image files exist for the theme's solar configuration
-    fn validate_theme_image_files(
-        theme_directory: &Path,
-        expected_image_indices: &[u8],
-        image_file_format: &str,
-    ) -> bool {
-        let images_directory_path = theme_directory.join(image_file_format);
+    fn validate_images(theme_dir: &Path, indices: &[u8], format: &str) -> bool {
+        let images_dir = theme_dir.join(format);
 
-        if !images_directory_path.is_dir() {
+        if !images_dir.is_dir() {
             warn!(
-                images_directory = %images_directory_path.display(),
+                images_dir = %images_dir.display(),
                 "Theme images directory not found or is not a directory"
             );
             return false;
         }
 
-        let mut missing_images_count = 0;
-        let validation_successful = expected_image_indices.iter().all(|&image_index| {
-            let image_filename = format!("{}.{}", image_index + 1, image_file_format);
-            let image_file_path = images_directory_path.join(image_filename);
-
-            let image_exists = image_file_path.exists() && image_file_path.is_file();
-            if !image_exists {
-                missing_images_count += 1;
-                warn!(
-                    image_path = %image_file_path.display(),
-                    image_index = image_index,
-                    "Required theme image file is missing"
-                );
+        let mut missing = 0usize;
+        let valid = indices.iter().all(|&idx| {
+            let filename = format!("{}.{}", idx + 1, format);
+            let path = images_dir.join(&filename);
+            let exists = path.exists() && path.is_file();
+            if !exists {
+                missing += 1;
+                warn!(image_path = %path.display(), index = idx, "Required theme image file is missing");
             }
-            image_exists
+            exists
         });
 
-        if !validation_successful {
+        if !valid {
             error!(
-                missing_images = missing_images_count,
-                total_expected = expected_image_indices.len(),
+                missing,
+                total = indices.len(),
                 "Theme image validation failed due to missing files"
             );
         }
 
-        validation_successful
+        valid
     }
 }
 
 thread_local! {
-    /// Cache solar configuration to avoid repeated reads
+    /// Cache solar configuration to avoid repeated disk reads
     static SOLAR_CACHE: RefCell<HashMap<PathBuf, Vec<SolarAngle>>> =
         RefCell::new(HashMap::new());
 }
 
-/// Load solar configuration for a specific theme directory
-fn load_cached_solar_angles(theme_directory: &Path) -> DwallResult<Vec<SolarAngle>> {
-    let theme_directory = theme_directory.canonicalize()?;
-    debug!(path = %theme_directory.display(), "Loading solar configuration from canonical and absolute path");
+/// Load solar angles for a theme directory, using an in-memory cache
+fn load_solar_angles_cached(theme_dir: &Path) -> DwallResult<Vec<SolarAngle>> {
+    let canonical = theme_dir.canonicalize()?;
+    debug!(path = %canonical.display(), "Loading solar configuration");
 
-    // Check cache
-    {
-        if let Some(cached_angles) =
-            SOLAR_CACHE.with(|cache| cache.borrow().get(&theme_directory).cloned())
-        {
-            debug!("Using cached solar configuration");
-            return Ok(cached_angles);
-        }
+    if let Some(cached) = SOLAR_CACHE.with(|c| c.borrow().get(&canonical).cloned()) {
+        debug!("Using cached solar configuration");
+        return Ok(cached);
     }
-    let solar_config_path = theme_directory.join("solar.json");
-    // Validate solar configuration file exists
-    if !solar_config_path.exists() {
-        error!(
-            solar_config_path = %solar_config_path.display(),
-            "Solar configuration file is missing"
-        );
-        return Err(ThemeProcessingError::SolarConfigurationMissing.into());
+
+    let config_path = canonical.join(SOLAR_CONFIG_FILE);
+
+    if !config_path.exists() {
+        error!(config_path = %config_path.display(), "Solar configuration file is missing");
+        return Err(ThemeError::SolarConfigMissing.into());
     }
-    // Read solar configuration file
-    let solar_config_content = match fs::read_to_string(&solar_config_path) {
-        Ok(content) => content,
-        Err(read_error) => {
-            error!(
-                solar_config_path = %solar_config_path.display(),
-                error = ?read_error,
-                "Failed to read solar configuration file"
-            );
-            return Err(read_error.into());
-        }
-    };
-    // Parse solar configuration
-    let solar_angles: Vec<SolarAngle> = match serde_json::from_str(&solar_config_content) {
-        Ok(angles) => angles,
-        Err(parse_error) => {
-            error!(
-                solar_config_path = %solar_config_path.display(),
-                error = ?parse_error,
-                "Failed to parse solar configuration JSON"
-            );
-            return Err(parse_error.into());
-        }
-    };
+
+    let content = fs::read_to_string(&config_path).map_err(|e| {
+        error!(config_path = %config_path.display(), error = ?e, "Failed to read solar configuration file");
+        e
+    })?;
+
+    let angles: Vec<SolarAngle> = serde_json::from_str(&content).map_err(|e| {
+        error!(config_path = %config_path.display(), error = ?e, "Failed to parse solar configuration JSON");
+        e
+    })?;
+
     debug!(
-        solar_angles_count = solar_angles.len(),
+        count = angles.len(),
         "Successfully loaded solar configuration"
     );
 
-    // Cache solar configuration
-    SOLAR_CACHE.with(|cache| {
-        cache
-            .borrow_mut()
-            .insert(theme_directory.to_path_buf(), solar_angles.clone());
+    SOLAR_CACHE.with(|c| {
+        c.borrow_mut().insert(canonical, angles.clone());
     });
 
-    Ok(solar_angles)
+    Ok(angles)
 }
 
-/// Build wallpaper file path based on theme directory, image format, and solar image index
-fn construct_wallpaper_file_path<'a>(
-    theme_directory_path: &Path,
-    image_file_format: impl Into<&'a str>,
-    solar_image_index: u8,
-) -> PathBuf {
-    let image_format_str = image_file_format.into();
-    let mut wallpaper_path = theme_directory_path.to_path_buf();
-    wallpaper_path.push(image_format_str);
-    wallpaper_path.push(format!("{}.{}", solar_image_index + 1, image_format_str));
-    wallpaper_path
+/// Build the wallpaper file path from a theme directory, image format, and solar image index
+fn wallpaper_path<'a>(theme_dir: &Path, format: impl Into<&'a str>, index: u8) -> PathBuf {
+    let fmt = format.into();
+    theme_dir.join(fmt).join(format!("{}.{}", index + 1, fmt))
 }
 
 /// Find the wallpaper image that best matches the current solar position
-fn find_optimal_solar_wallpaper(
-    theme_directory_path: &Path,
-    current_sun_position: &SunPosition,
+fn best_wallpaper_for_sun(
+    theme_dir: &Path,
+    sun: &SunPosition,
 ) -> DwallResult<(u8, Vec<SolarAngle>)> {
-    let solar_angle_configuration = load_cached_solar_angles(theme_directory_path)?;
-    let sun_altitude_degrees = current_sun_position.altitude();
-    let sun_azimuth_degrees = current_sun_position.azimuth();
+    let angles = load_solar_angles_cached(theme_dir)?;
+    let altitude = sun.altitude();
+    let azimuth = sun.azimuth();
 
     debug!(
-        sun_altitude = sun_altitude_degrees,
-        sun_azimuth = sun_azimuth_degrees,
-        theme_directory = %theme_directory_path.display(),
-        "Calculated current solar position for wallpaper selection"
+        altitude,
+        azimuth,
+        theme_dir = %theme_dir.display(),
+        "Selecting wallpaper for solar position"
     );
 
-    let optimal_image_index = WallpaperSetter::find_closest_image(
-        &solar_angle_configuration,
-        sun_altitude_degrees,
-        sun_azimuth_degrees,
-    )
-    .ok_or_else(|| {
-        error!(
-            theme_directory = %theme_directory_path.display(),
-            sun_altitude = sun_altitude_degrees,
-            sun_azimuth = sun_azimuth_degrees,
-            solar_angles_available = solar_angle_configuration.len(),
-            "No suitable wallpaper image found for current solar position"
-        );
-        ThemeProcessingError::ImageSolarConfigurationMismatch {
-            expected: solar_angle_configuration.len(),
-            found: 0,
-        }
-    })?;
-
-    info!(
-        optimal_image_index,
-        sun_altitude = sun_altitude_degrees,
-        sun_azimuth = sun_azimuth_degrees,
-        "Selected optimal wallpaper image for current solar position"
-    );
-
-    Ok((optimal_image_index, solar_angle_configuration))
-}
-
-/// Core solar theme processing function that updates wallpapers for all monitors
-fn process_solar_theme_cycle(
-    configuration: &Config,
-    current_geographic_position: &Position,
-    wallpaper_manager: &WallpaperSetter,
-) -> DwallResult<()> {
-    debug!(
-        auto_detect_color_mode = configuration.auto_detect_color_scheme(),
-        image_format = ?configuration.image_format(),
-        latitude = current_geographic_position.latitude(),
-        longitude = current_geographic_position.longitude(),
-        "Starting solar theme processing cycle"
-    );
-
-    let available_monitors = wallpaper_manager.list_available_monitors()?;
-    let monitor_theme_configurations = configuration.monitor_specific_wallpapers();
-
-    let current_utc_time = UtcDateTime::now();
-    let current_sun_position = SunPosition::new(
-        current_geographic_position.latitude(),
-        current_geographic_position.longitude(),
-        current_utc_time,
-    );
-
-    let mut lock_screen_theme_identifier: Option<String> = None;
-    let mut successful_monitor_count = 0;
-
-    // Process wallpaper update for each configured monitor
-    for monitor_identifier in available_monitors.keys() {
-        let assigned_theme_id: &str = match monitor_theme_configurations.get(monitor_identifier) {
-            Some(theme_id) => theme_id.as_ref(),
-            None => {
-                debug!(
-                    monitor_id = monitor_identifier,
-                    "No theme configuration found for monitor, skipping"
-                );
-                continue;
-            }
-        };
-
-        info!(
-            monitor_id = monitor_identifier,
-            assigned_theme = assigned_theme_id,
-            "Processing solar wallpaper for monitor"
-        );
-
-        // Use the first successfully configured theme for lock screen
-        if lock_screen_theme_identifier.is_none() {
-            lock_screen_theme_identifier = Some(assigned_theme_id.to_string());
-        }
-
-        if let Err(processing_error) = update_monitor_solar_wallpaper(
-            configuration,
-            monitor_identifier,
-            assigned_theme_id,
-            &current_sun_position,
-            wallpaper_manager,
-        ) {
+    let index =
+        WallpaperSetter::find_closest_image(&angles, altitude, azimuth).ok_or_else(|| {
             error!(
-                error = %processing_error,
-                monitor_id = monitor_identifier,
-                theme_id = assigned_theme_id,
-                "Failed to update solar wallpaper for monitor"
+                theme_dir = %theme_dir.display(),
+                altitude,
+                azimuth,
+                available = angles.len(),
+                "No suitable wallpaper found for current solar position"
             );
-            continue;
-        }
-
-        successful_monitor_count += 1;
-    }
-
-    // Update lock screen wallpaper if enabled and at least one monitor was successful
-    if configuration.lock_screen_wallpaper_enabled()
-        && successful_monitor_count > 0
-        && let Some(ref lock_screen_theme_id) = lock_screen_theme_identifier
-        && let Err(lock_screen_error) = apply_lock_screen_solar_wallpaper(
-            configuration,
-            lock_screen_theme_id,
-            &current_sun_position,
-        )
-    {
-        warn!(
-            error = %lock_screen_error,
-            theme_id = lock_screen_theme_id,
-            "Failed to apply solar wallpaper to lock screen, continuing with other operations"
-        );
-    }
-
-    // Optionally update system color scheme based on solar position
-    if configuration.auto_detect_color_scheme() {
-        let current_color_scheme = ColorSchemeManager::get_current_scheme()?;
-        let solar_based_color_scheme = determine_color_scheme_with_hysteresis(
-            current_sun_position.altitude(),
-            &current_color_scheme,
-            &ThresholdConfig::from_location(current_geographic_position),
-        );
-        info!(
-            color_scheme = ?solar_based_color_scheme,
-            sun_altitude = current_sun_position.altitude(),
-            "Automatically updating system color scheme based on solar position"
-        );
-        if let Err(color_scheme_error) = set_color_scheme(solar_based_color_scheme) {
-            warn!(
-                error = %color_scheme_error,
-                "Failed to update system color scheme, continuing with other operations"
-            );
-        }
-    }
+            ThemeError::ImageConfigMismatch {
+                expected: angles.len(),
+                found: 0,
+            }
+        })?;
 
     info!(
-        successful_monitors = successful_monitor_count,
-        total_monitors = available_monitors.len(),
-        "Solar theme processing cycle completed"
+        index,
+        altitude, azimuth, "Selected optimal wallpaper for solar position"
     );
 
-    Ok(())
+    Ok((index, angles))
 }
 
-/// Update solar wallpaper for a specific monitor based on current sun position
-fn update_monitor_solar_wallpaper(
-    configuration: &Config,
-    monitor_identifier: &str,
-    theme_identifier: &str,
-    current_sun_position: &SunPosition,
-    wallpaper_manager: &WallpaperSetter,
+/// Apply the optimal solar wallpaper to a specific monitor
+fn set_monitor_wallpaper(
+    config: &Config,
+    monitor_id: &str,
+    theme_id: &str,
+    sun: &SunPosition,
+    setter: &WallpaperSetter,
 ) -> DwallResult<()> {
-    let theme_directory_path = configuration.themes_directory().join(theme_identifier);
-    let (optimal_image_index, _) =
-        find_optimal_solar_wallpaper(&theme_directory_path, current_sun_position)?;
-    let wallpaper_file_path = construct_wallpaper_file_path(
-        &theme_directory_path,
-        configuration.image_format(),
-        optimal_image_index,
-    );
+    let theme_dir = config.themes_directory().join(theme_id);
+    let (index, _) = best_wallpaper_for_sun(&theme_dir, sun)?;
+    let path = wallpaper_path(&theme_dir, config.image_format(), index);
 
     info!(
-        wallpaper_path = %wallpaper_file_path.display(),
-        image_index = optimal_image_index,
-        monitor_id = monitor_identifier,
-        theme_id = theme_identifier,
-        "Selected optimal solar wallpaper for monitor"
+        path = %path.display(),
+        index,
+        monitor_id,
+        theme_id,
+        "Selected optimal wallpaper for monitor"
     );
 
-    if !wallpaper_file_path.exists() {
-        error!(
-            wallpaper_path = %wallpaper_file_path.display(),
-            theme_id = theme_identifier,
-            "Selected wallpaper image file does not exist"
-        );
-        return Err(ThemeProcessingError::WallpaperImageMissing {
-            path: wallpaper_file_path.display().to_string(),
+    if !path.exists() {
+        error!(path = %path.display(), theme_id, "Wallpaper image file does not exist");
+        return Err(ThemeError::WallpaperMissing {
+            path: path.display().to_string(),
         }
         .into());
     }
 
-    wallpaper_manager.set_monitor_wallpaper(monitor_identifier, &wallpaper_file_path)?;
+    setter.set_monitor_wallpaper(monitor_id, &path)?;
 
-    debug!(
-        monitor_id = monitor_identifier,
-        wallpaper_path = %wallpaper_file_path.display(),
-        "Successfully applied solar wallpaper to monitor"
-    );
+    debug!(monitor_id, path = %path.display(), "Successfully applied wallpaper to monitor");
 
     Ok(())
 }
 
-/// Apply solar wallpaper to lock screen based on theme and current sun position
-fn apply_lock_screen_solar_wallpaper(
-    configuration: &Config,
-    theme_identifier: &str,
-    current_sun_position: &SunPosition,
+/// Apply the optimal solar wallpaper to the lock screen
+fn set_lock_screen_wallpaper(
+    config: &Config,
+    theme_id: &str,
+    sun: &SunPosition,
 ) -> DwallResult<()> {
-    let theme_directory_path = configuration.themes_directory().join(theme_identifier);
+    let theme_dir = config.themes_directory().join(theme_id);
 
-    match find_optimal_solar_wallpaper(&theme_directory_path, current_sun_position) {
-        Ok((optimal_image_index, _)) => {
-            let wallpaper_file_path = construct_wallpaper_file_path(
-                &theme_directory_path,
-                configuration.image_format(),
-                optimal_image_index,
-            );
+    match best_wallpaper_for_sun(&theme_dir, sun) {
+        Ok((index, _)) => {
+            let path = wallpaper_path(&theme_dir, config.image_format(), index);
 
-            if wallpaper_file_path.exists() {
-                info!(
-                    wallpaper_path = %wallpaper_file_path.display(),
-                    theme_id = theme_identifier,
-                    "Applying optimal solar wallpaper to lock screen"
-                );
-                WallpaperSetter::set_lock_screen_image(&wallpaper_file_path)?;
+            if path.exists() {
+                info!(path = %path.display(), theme_id, "Applying wallpaper to lock screen");
+                WallpaperSetter::set_lock_screen_image(&path)?;
             } else {
-                warn!(
-                    wallpaper_path = %wallpaper_file_path.display(),
-                    theme_id = theme_identifier,
-                    "Optimal lock screen wallpaper file does not exist"
-                );
-                return Err(ThemeProcessingError::WallpaperImageMissing {
-                    path: wallpaper_file_path.display().to_string(),
+                warn!(path = %path.display(), theme_id, "Lock screen wallpaper file does not exist");
+                return Err(ThemeError::WallpaperMissing {
+                    path: path.display().to_string(),
                 }
                 .into());
             }
             Ok(())
         }
-        Err(wallpaper_error) => {
-            warn!(
-                error = %wallpaper_error,
-                theme_id = theme_identifier,
-                "Failed to find optimal solar wallpaper for lock screen"
-            );
-            Err(wallpaper_error)
+        Err(e) => {
+            warn!(error = %e, theme_id, "Failed to find optimal wallpaper for lock screen");
+            Err(e)
         }
     }
 }
 
 /// Applies a solar theme and starts background processing for periodic wallpaper updates
-pub async fn apply_solar_theme(configuration: Config) -> DwallResult<()> {
-    if configuration.monitor_specific_wallpapers().is_empty() {
+pub async fn apply_solar_theme(config: Config) -> DwallResult<()> {
+    if config.monitor_specific_wallpapers().is_empty() {
         warn!(
             "No monitor-specific wallpaper configurations found, solar theme daemon will not be started"
         );
-        return Err(ThemeProcessingError::MonitorWallpaperConfigurationMissing.into());
+        return Err(ThemeError::NoMonitorConfig.into());
     }
 
     info!(
-        configured_monitors = ?configuration.monitor_specific_wallpapers(),
+        monitors = ?config.monitor_specific_wallpapers(),
         "Starting solar theme processor with monitor configurations"
     );
 
-    let solar_theme_processor = SolarThemeProcessor::new(&configuration)?;
-    solar_theme_processor.start_solar_update_loop()
+    ThemeProcessor::new(&config)?.start_update_loop()
 }

--- a/crates/dwall/src/error.rs
+++ b/crates/dwall/src/error.rs
@@ -1,5 +1,5 @@
 use crate::domain::geography::{CoordinateError, GeolocationAccessError};
-use crate::domain::visual::ThemeProcessingError;
+use crate::domain::visual::ThemeError;
 use crate::infrastructure::display::DisplayError;
 use crate::infrastructure::display::WallpaperError;
 use crate::infrastructure::platform::windows::RegistryError;
@@ -22,7 +22,7 @@ pub enum DwallError {
 
     /// Theme-related error
     #[error("Theme processing error: {0}")]
-    ThemeProcessing(#[from] ThemeProcessingError),
+    ThemeProcessing(#[from] ThemeError),
 
     /// JSON serialization/deserialization error
     #[error("JSON processing failed: {0}")]

--- a/crates/dwall/src/lib.rs
+++ b/crates/dwall/src/lib.rs
@@ -18,7 +18,7 @@ pub use utils::logging::setup_logging;
 
 // Re-export domain types
 pub use domain::geography::Position;
-pub use domain::visual::{SolarThemeValidator, apply_solar_theme};
+pub use domain::visual::{ThemeValidator, apply_solar_theme};
 
 // Re-export infrastructure types
 pub use infrastructure::display::{DisplayMonitor, DisplayMonitorProvider};

--- a/crates/dwall/src/utils/datetime/mod.rs
+++ b/crates/dwall/src/utils/datetime/mod.rs
@@ -4,6 +4,7 @@ mod math;
 mod month;
 
 use std::fmt;
+use std::ops::Add;
 use std::time::{Duration, SystemTime};
 
 use crate::utils::datetime::consts::{SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE};
@@ -181,6 +182,14 @@ impl UtcDateTime {
             .checked_add(Duration::from_secs(secs))
             .map(|inner| Self { inner })
             .ok_or(DateTimeError::Overflow)
+    }
+
+    /// Adds the specified number of seconds without checking for overflow.
+    #[inline]
+    pub fn add_seconds_unchecked(&self, secs: u64) -> Self {
+        Self {
+            inner: self.inner.add(Duration::from_secs(secs)),
+        }
     }
 
     /// Adds the specified number of minutes.


### PR DESCRIPTION
## Why time-based theme switching is better than altitude thresholds

### The old approach and its problems

The previous implementation determined light/dark mode by comparing the sun's current altitude angle against a fixed threshold (civil twilight, −6°). While conceptually simple, this approach had several inherent weaknesses.

**Altitude thresholds are a proxy, not the real signal.** What users actually experience as "day" and "night" is defined by sunrise and sunset — not by whether the sun happens to sit above or below an arbitrary angle. The −6° threshold is a reasonable approximation on average, but it is not what macOS or any major platform uses in practice.

**Latitude compensation was fragile.** Because twilight duration varies significantly by latitude — short near the equator, extremely long near the poles — the original code manually adjusted the threshold angle for different latitude zones (tropical, mid-latitude, high-latitude, polar). This introduced a piecewise approximation with hard-coded boundaries (23.5°, 45°, 66.5°) that do not reflect how twilight actually behaves across the year at a given location. A location at 50°N in June and the same location in December have very different twilight durations, but the old code applied the same threshold adjustment in both cases.

**Polar regions required special-casing the wrong thing.** To handle polar day and polar night, the threshold was pushed deeper (toward −12°), which masked the real issue: at extreme latitudes the sun may never cross any fixed altitude threshold at all. This produced silent failures rather than explicit, correct behavior.

### What the new approach does instead

The new implementation calculates the actual sunrise and sunset times for the current date and location using a binary search over `SunPosition::altitude()`. Theme switching is then scheduled around those two events directly.

**The switching signal is meaningful to users.** "Switch to dark mode at sunset" matches user intuition precisely, because it is literally what sunset means. No threshold calibration is required.

**Latitude and season are handled for free.** Sunrise and sunset times already encode every relevant factor — latitude, longitude, time of year, and the equation of time. A location in northern Norway in winter will have a sunrise at 11:00 and a sunset at 13:00; the scheduler simply switches at those times. No zone boundaries or adjustment coefficients are needed.

**Polar day and polar night are explicit, not approximated.** When no sunrise or sunset exists for the current date and location, the code detects this directly and holds the appropriate scheme for the entire day. The behavior is correct by construction rather than by threshold tuning.

**Hysteresis operates in time, not degrees.** The original ±0.5° band is difficult to reason about in practical terms. The new ±5-minute window has a clear, human-readable meaning and is applied symmetrically around the scheduled event time.

**Computation is amortized.** Sunrise and sunset for a given date and location only need to be calculated once per day. The result is cached against a composite key of the calendar date and the rounded geographic position, so repeated calls within a day are O(1). The cache also correctly invalidates when the user's location changes beyond 111 meters, preventing stale schedules without recomputing on every GPS update.