### PR TITLE
refactor: remove unused 'locale' statement in useFontLoader

### DIFF
--- a/src/hooks/useFontLoader.ts
+++ b/src/hooks/useFontLoader.ts
@@ -135,8 +135,6 @@ function loadGoogleFonts(locale: Locale): void {
 
 // ─── Hook ─────────────────────────────────────────────────────
 export function useFontLoader(options?: UseFontLoaderOptions) {
-  locale;
-
   const { apply = true } = options ?? {};
 
   createEffect(() => {


### PR DESCRIPTION
- Deleted the standalone `locale;` line inside the `useFontLoader` hook