### PR TITLE
refactor: remove undefined from aspectRatioRef type

### DIFF
--- a/src/layout/theme/Theme.tsx
+++ b/src/layout/theme/Theme.tsx
@@ -35,7 +35,7 @@ export const Theme = (props: ThemeProps) => {
   } = useMonitor();
   const { downloadingTheme } = useTheme();
 
-  let aspectRatioRef: HTMLDivElement | undefined;
+  let aspectRatioRef!: HTMLDivElement;
 
   const [indicatorsBottom, setIndicatorsBottom] = createSignal(10);
   const [nameTop, setNameTop] = createSignal(8);


### PR DESCRIPTION
- Changed type of `aspectRatioRef` from `HTMLDivElement | undefined` to `HTMLDivElement` using definite assignment assertion (`!`)