### PR TITLE
fix(logging): default to debug log level in nightly builds

### DIFF
--- a/crates/logging/build.rs
+++ b/crates/logging/build.rs
@@ -1,0 +1,9 @@
+use std::io;
+
+fn main() -> io::Result<()> {
+    if cfg!(not(feature = "max-level-info")) {
+        println!("cargo:rustc-env=DWALL_LOG=debug");
+    };
+
+    Ok(())
+}

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -185,10 +185,9 @@ const fn default_log_level() -> LevelFilter {
 
 /// Get log level from environment variable
 fn get_log_level() -> LevelFilter {
-    env::var("DWALL_LOG")
-        .ok()
-        .or_else(|| env::var("RUST_LOG").ok())
-        .as_deref()
+    option_env!("DWALL_LOG")
+        .or(env::var("DWALL_LOG").ok().as_deref())
+        .or(env::var("RUST_LOG").ok().as_deref())
         .and_then(|level| LevelFilter::from_str(level).ok())
         .unwrap_or_else(default_log_level)
 }


### PR DESCRIPTION
- Add build.rs to set DWALL_LOG=debug at compile time when feature "max-level-info" is not enabled
- Prioritize compile-time DWALL_LOG env via option_env! before runtime env vars