### PR TITLE
ci: add target/debug paths to cache

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -110,6 +110,8 @@ jobs:
             ~/.cargo/git/db/
             target/release/deps
             target/release/build
+            target/debug/deps
+            target/debug/build
           key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-rust-


### PR DESCRIPTION
- Added `target/debug/deps` and `target/debug/build` to cache paths in pr-check workflow