### PR TITLE
fix: adjust customized theme path resolution for validation and listing

### DIFF
--- a/crates/dwall-settings/src/app/commands.rs
+++ b/crates/dwall-settings/src/app/commands.rs
@@ -96,8 +96,9 @@ pub async fn open_privacy_location_settings() -> DwallSettingsResult<()> {
 pub async fn validate_theme_cmd(
     themes_directory: &Path,
     theme_id: &str,
+    is_customized: bool,
 ) -> DwallSettingsResult<()> {
-    validate_solar_theme(themes_directory, theme_id).map_err(Into::into)
+    validate_solar_theme(themes_directory, theme_id, is_customized).map_err(Into::into)
 }
 
 #[tauri::command]
@@ -257,17 +258,16 @@ pub struct Theme {
 pub async fn get_customized_themes_cmd(
     customized_themes_directory: PathBuf,
 ) -> DwallSettingsResult<Vec<Theme>> {
-    let thumbnails_dir = customized_themes_directory.join("thumbnails");
-    if !thumbnails_dir.exists() {
+    if !customized_themes_directory.exists() {
         return Ok(Vec::new());
     }
 
-    let subdirs = list_subdirectories(&thumbnails_dir).await?;
+    let subdirs = list_subdirectories(&customized_themes_directory).await?;
     debug!("Found {} subdirectories", subdirs.len());
 
     let mut themes = Vec::with_capacity(subdirs.len());
     for subdir in subdirs {
-        let files = find_files_in_dir(&subdir, "avif").await?;
+        let files = find_files_in_dir(&subdir.join("thumbnails"), "avif").await?;
         let id = subdir
             .file_name()
             .and_then(|n| n.to_str())

--- a/crates/dwall-settings/src/domain/theme.rs
+++ b/crates/dwall-settings/src/domain/theme.rs
@@ -18,8 +18,9 @@ struct DaemonLogEntry {
 pub fn validate_solar_theme(
     themes_directory: &Path,
     theme_id: &str,
+    is_customized: bool,
 ) -> Result<(), dwall::error::DwallError> {
-    ThemeValidator::validate(themes_directory, theme_id)
+    ThemeValidator::validate(themes_directory, theme_id, is_customized)
 }
 
 /// Attempts to read the most recent error from the daemon log file

--- a/crates/dwall/src/domain/visual/theme_processor.rs
+++ b/crates/dwall/src/domain/visual/theme_processor.rs
@@ -250,14 +250,22 @@ pub struct ThemeValidator;
 
 impl ThemeValidator {
     /// Validates if a solar theme exists and has proper configuration and image files
-    pub fn validate(themes_directory: &Path, theme_identifier: &str) -> DwallResult<()> {
+    pub fn validate(
+        themes_directory: &Path,
+        theme_identifier: &str,
+        is_customized: bool,
+    ) -> DwallResult<()> {
         trace!(
             theme_id = theme_identifier,
             themes_directory = %themes_directory.display(),
             "Starting solar theme validation"
         );
 
-        let theme_directory_path = themes_directory.join(theme_identifier);
+        let theme_directory_path = if is_customized {
+            themes_directory.join(theme_identifier).join("images")
+        } else {
+            themes_directory.join(theme_identifier)
+        };
 
         if !theme_directory_path.exists() {
             warn!(
@@ -292,6 +300,7 @@ impl ThemeValidator {
         info!(
             theme_id = theme_identifier,
             solar_angles_count = solar_angle_configuration.len(),
+            is_customized = is_customized,
             "Solar theme validation completed successfully"
         );
         Ok(())
@@ -745,8 +754,8 @@ fn get_theme_directory_path(configuration: &Config, theme_identifier: &str) -> P
     if !path.exists() {
         path = configuration
             .customized_themes_directory()
-            .join("themes")
-            .join(theme_identifier);
+            .join(theme_identifier)
+            .join("images");
     }
     path
 }

--- a/src/commands/theme.ts
+++ b/src/commands/theme.ts
@@ -1,8 +1,16 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { ThemeID, ThemeItem } from "~/themes";
 
-export const validateTheme = async (themesDirectory: string, themeId: string) =>
-  invoke<void>("validate_theme_cmd", { themesDirectory, themeId });
+export const validateTheme = async (
+  themesDirectory: string,
+  themeId: string,
+  isCustomized = false,
+) =>
+  invoke<void>("validate_theme_cmd", {
+    themesDirectory,
+    themeId,
+    isCustomized,
+  });
 
 export const applyTheme = async (config: Config) =>
   invoke<void>("apply_theme_cmd", { config });

--- a/src/layout/theme/Actions.tsx
+++ b/src/layout/theme/Actions.tsx
@@ -42,7 +42,11 @@ const ThemeActions = (props: ThemeActionsProps) => {
     }
 
     try {
-      await validateTheme(props.themesDirectory, props.currentThemeID);
+      await validateTheme(
+        props.themesDirectory,
+        props.currentThemeID,
+        props.isCustomized,
+      );
       setThemeExists(true);
     } catch (e) {
       setThemeExists(false);

--- a/src/layout/theme/Theme.tsx
+++ b/src/layout/theme/Theme.tsx
@@ -153,9 +153,10 @@ export const Theme = (props: ThemeProps) => {
           currentThemeID={props.id}
           themesDirectory={
             theme()?.isCustomized
-              ? `${config()?.customized_themes_directory}\\themes`
+              ? config()?.customized_themes_directory
               : config()?.themes_directory
           }
+          isCustomized={theme()?.isCustomized}
         />
       </div>
     </div>


### PR DESCRIPTION
- Add is_customized parameter to validation functions (cmd, domain, processor)
- Validate customized theme images under {theme_id}/images subdirectory
- Fix customized themes listing to scan thumbnails under {theme_id}/thumbnails
- Update frontend validateTheme to pass isCustomized flag
- Correct themesDirectory path for customized themes (remove extra 'themes' segment)