### PR TITLE
refactor(logging): replace colors module with rich formatting

### DIFF
--- a/crates/logging/src/colors.rs
+++ b/crates/logging/src/colors.rs
@@ -1,9 +1,0 @@
-pub(super) const RESET: &str = "\x1b[0m";
-pub(super) const BOLD: &str = "\x1b[1m";
-pub(super) const DIM: &str = "\x1b[2m";
-
-pub(super) const RED: &str = "\x1b[31m";
-pub(super) const YELLOW: &str = "\x1b[33m";
-pub(super) const CYAN: &str = "\x1b[36m";
-pub(super) const WHITE: &str = "\x1b[37m";
-pub(super) const MAGENTA: &str = "\x1b[35m";

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -3,9 +3,9 @@ use std::{env, io::Write, str::FromStr};
 use log::{LevelFilter, Log, SetLoggerError, set_boxed_logger, set_max_level};
 use time::{OffsetDateTime, UtcDateTime};
 
-#[cfg(debug_assertions)]
-mod colors;
 mod macros;
+#[cfg(debug_assertions)]
+mod rich;
 
 #[doc(hidden)]
 pub const LOG_MAX_LEVEL_INFO: bool = cfg!(feature = "max-level-info");
@@ -129,7 +129,9 @@ impl Log for Logger {
 
         #[cfg(debug_assertions)]
         {
-            use crate::colors::{BOLD, CYAN, DIM, MAGENTA, RED, RESET, WHITE, YELLOW};
+            use crate::rich::{
+                BOLD, CYAN, DIM, ITALIC, MAGENTA, RED, RESET, WHITE, YELLOW, restore_color,
+            };
 
             let (level_color, level_str) = match record.level() {
                 log::Level::Error => (RED, "ERROR"),
@@ -142,12 +144,16 @@ impl Log for Logger {
             let file = record.file().unwrap_or("<unknown>");
             let line = record.line().unwrap_or(0);
 
+            //   2026-06-01T01:27:42.340486Z DEBUG  Reading configuration file, path: C:\Users\wzl03\AppData\Roaming\dwall\config.toml
+            //     at src\config.rs:79
+
+            let msg = record.args().to_string();
+            let msg = restore_color(&msg, level_color);
             eprintln!(
-                "{DIM}{timestamp}{RESET} \
-                 {BOLD}{level_color}{level_str}{RESET} \
-                 {DIM}[{file}:{line}]{RESET} \
-                 {}",
-                record.args(),
+                "  {DIM}{timestamp}{RESET} \
+                 {BOLD}{level_color}{level_str}{RESET} {level_color}{}{RESET}\n    \
+                 {DIM}{ITALIC}at{RESET} {file}:{line}\n",
+                msg,
             );
         }
 
@@ -235,4 +241,22 @@ fn get_log_level() -> LevelFilter {
         .or(option_env!("DWALL_LOG"))
         .and_then(|s| LevelFilter::from_str(s).ok())
         .unwrap_or_else(default_log_level)
+}
+
+/// In debug builds, wraps the key name with ANSI bold-italic escape codes.
+/// In release builds, returns the key as-is with zero overhead.
+#[cfg(debug_assertions)]
+#[doc(hidden)]
+#[inline(always)]
+pub fn __fmt_key(key: &'static str) -> String {
+    use crate::rich::{BOLD, ITALIC, RESET};
+
+    format!("{BOLD}{ITALIC}{key}{RESET}")
+}
+
+#[cfg(not(debug_assertions))]
+#[doc(hidden)]
+#[inline(always)]
+pub fn __fmt_key(key: &'static str) -> &'static str {
+    key
 }

--- a/crates/logging/src/macros.rs
+++ b/crates/logging/src/macros.rs
@@ -1,48 +1,53 @@
-/// Internal processing macro that recursively parses tracing-style key-value pairs and separates them from the main message for passing.
+/// Internal processing macro that recursively parses tracing-style key-value pairs.
+///
+/// Output format:  `{message}, {key1}={val1}, {key2}={val2}, ...`
+/// In debug builds, each key is rendered with ANSI bold-italic styling.
 #[macro_export]
 macro_rules! kv_log_internal {
-    // Base case 1: without target
+    // ── Base case 1: no target ───────────────────────────────────────────────
+    // Accumulated kv segments are each prefixed with ", " so the final string is:
+    //   "{msg}, k1=v1, k2=v2"
     (@build $lvl:ident () ($($kv_fmt:tt)*) ($($kv_args:expr,)*) $msg:literal $(, $($msg_args:tt)*)?) => {
         ::log::$lvl!(
-            concat!("{} ", $($kv_fmt)*),
+            concat!("{}", $($kv_fmt)*),
             format_args!($msg $(, $($msg_args)*)?),
             $($kv_args,)*
         )
     };
 
-    // Base case 2: with target
+    // ── Base case 2: with target ─────────────────────────────────────────────
     (@build $lvl:ident (target: $tgt:expr) ($($kv_fmt:tt)*) ($($kv_args:expr,)*) $msg:literal $(, $($msg_args:tt)*)?) => {
         ::log::$lvl!(
             target: $tgt,
-            concat!("{} ", $($kv_fmt)*),
+            concat!("{}", $($kv_fmt)*),
             format_args!($msg $(, $($msg_args)*)?),
             $($kv_args,)*
         )
     };
 
-    // Parse key-value pair with % prefix (Display)
+    // ── key = %value  (Display) ──────────────────────────────────────────────
     (@build $lvl:ident $tgt:tt ($($kv_fmt:tt)*) ($($kv_args:expr,)*) $k:ident = %$v:expr, $($rest:tt)+) => {
         $crate::kv_log_internal!(@build $lvl $tgt
-            ($($kv_fmt)* stringify!($k), "={} ",)
-            ($($kv_args,)* $v,)
+            ($($kv_fmt)* ", {}={}",)
+            ($($kv_args,)* $crate::__fmt_key(::core::stringify!($k)), $v,)
             $($rest)+
         )
     };
 
-    // Parse key-value pair with ? prefix (Debug)
+    // ── key = ?value  (Debug) ────────────────────────────────────────────────
     (@build $lvl:ident $tgt:tt ($($kv_fmt:tt)*) ($($kv_args:expr,)*) $k:ident = ?$v:expr, $($rest:tt)+) => {
         $crate::kv_log_internal!(@build $lvl $tgt
-            ($($kv_fmt)* stringify!($k), "={:?} ",)
-            ($($kv_args,)* $v,)
+            ($($kv_fmt)* ", {}={:?}",)
+            ($($kv_args,)* $crate::__fmt_key(::core::stringify!($k)), $v,)
             $($rest)+
         )
     };
 
-    // Parse key-value pair without prefix (falls back to Debug)
+    // ── key = value  (Debug fallback) ────────────────────────────────────────
     (@build $lvl:ident $tgt:tt ($($kv_fmt:tt)*) ($($kv_args:expr,)*) $k:ident = $v:expr, $($rest:tt)+) => {
         $crate::kv_log_internal!(@build $lvl $tgt
-            ($($kv_fmt)* stringify!($k), "={:?} ",)
-            ($($kv_args,)* $v,)
+            ($($kv_fmt)* ", {}={:?}",)
+            ($($kv_args,)* $crate::__fmt_key(::core::stringify!($k)), $v,)
             $($rest)+
         )
     };

--- a/crates/logging/src/rich.rs
+++ b/crates/logging/src/rich.rs
@@ -1,0 +1,50 @@
+macro_rules! style {
+    (RESET) => {
+        "\x1b[0m"
+    };
+    (BOLD) => {
+        "\x1b[1m"
+    };
+    (DIM) => {
+        "\x1b[2m"
+    };
+    (ITALIC) => {
+        "\x1b[3m"
+    };
+    (RED) => {
+        "\x1b[31m"
+    };
+    (YELLOW) => {
+        "\x1b[33m"
+    };
+    (CYAN) => {
+        "\x1b[36m"
+    };
+    (MAGENTA) => {
+        "\x1b[35m"
+    };
+    (WHITE) => {
+        "\x1b[37m"
+    };
+
+    ($a:ident, $b:ident) => {
+        concat!(style!($a), style!($b))
+    };
+    ($a:ident, $b:ident, $c:ident) => {
+        concat!(style!($a), style!($b), style!($c))
+    };
+}
+
+pub(super) const RESET: &str = style!(RESET);
+pub(super) const BOLD: &str = style!(BOLD);
+pub(super) const DIM: &str = style!(DIM);
+pub(super) const ITALIC: &str = style!(ITALIC);
+pub(super) const RED: &str = style!(RED);
+pub(super) const YELLOW: &str = style!(YELLOW);
+pub(super) const CYAN: &str = style!(CYAN);
+pub(super) const MAGENTA: &str = style!(MAGENTA);
+pub(super) const WHITE: &str = style!(WHITE);
+
+pub(crate) fn restore_color(s: &str, base_color: &str) -> String {
+    s.replace(style!(RESET), &format!("{}{}", style!(RESET), base_color))
+}


### PR DESCRIPTION
- Remove colors.rs and its ANSI color constants
- Add rich.rs with style macro and restore_color utility
- Introduce ITALIC style and restore_color to reapply base color after RESET
- Improve log format: indent source location on a new line
- Add __fmt_key to apply bold-italic styling to key names in debug builds
- Update kv_log_internal macro: remove trailing space, format keys with __fmt_key, use ", " as separator