### PR TITLE
fix: update cache paths in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -283,8 +283,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            src-tauri/target/release/deps
-            src-tauri/target/release/build
+            target/release/deps
+            target/release/build
           key: ${{ runner.os }}-rust-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-rust-release-


### PR DESCRIPTION
Remove `src-tauri` prefix from Rust release cache paths to match the project's directory structure.