### PR TITLE
ci: optimize GitHub Actions caching for Rust and frontend

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -274,8 +274,12 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-registry-
 
@@ -285,7 +289,7 @@ jobs:
           path: |
             target/release/deps
             target/release/build
-          key: ${{ runner.os }}-rust-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-rust-release-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-rust-release-
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -211,7 +211,7 @@ jobs:
           bun-version: latest
 
       - name: Cache frontend dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun
@@ -225,19 +225,27 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
 
-      - name: Cache Rust dependencies
-        uses: actions/cache@v4
+      - name: Cache cargo registry
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
             target/release/deps
             target/release/build
-          key: ${{ runner.os }}-rust-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-rust-release-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-rust-
+            ${{ runner.os }}-rust-release-
 
       - name: Setup Biome CLI
         uses: biomejs/setup-biome@v2

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -43,6 +43,8 @@ jobs:
             ~/.bun
             node_modules/
           key: ${{ runner.os }}-frontend-${{ hashFiles('**/bun.lockb', '**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -63,8 +65,14 @@ jobs:
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-registry-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
 
       - name: Build dwall
         run: |
@@ -77,6 +85,8 @@ jobs:
             target/debug/deps
             target/debug/build
           key: ${{ runner.os }}-rust-debug-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-debug-
 
       - name: Build caches
         run: |


### PR DESCRIPTION
- Upgrade `actions/cache` from v4 to v5 in `publish.yml`
- Split cargo cache into granular paths (`bin/`, `registry/index/`, `registry/cache/`, `git/db/`) instead of caching whole `~/.cargo`
- Include toolchain cache key in cargo and Rust dependency cache keys to avoid stale caches after rustup updates
- Rename Rust cache keys for consistency (e.g., `rust-release` vs `rust`)
- Add missing `restore-keys` for frontend and debug Rust caches in `warm-cache.yml`