### PR TITLE
feat(theme): add PNG image format support for customized themes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,7 @@ dependencies = [
  "tauri-plugin-updater",
  "thiserror 2.0.18",
  "tokio",
+ "toml 1.1.2+spec-1.1.0",
  "windows",
  "zip 8.6.0",
 ]

--- a/crates/dwall-settings/Cargo.toml
+++ b/crates/dwall-settings/Cargo.toml
@@ -39,6 +39,7 @@ windows = { version = "0.61", default-features = false, features = [
     "Win32_System_Threading",
 ] }
 rand = { version = "0.10", default-features = false, features = ["thread_rng"] }
+toml = { version = "1", default-features = false, features = ["parse"] }
 
 tauri-plugin-shell = "2"
 tauri-plugin-single-instance = "2.4"

--- a/crates/dwall-settings/src/app/commands.rs
+++ b/crates/dwall-settings/src/app/commands.rs
@@ -5,21 +5,24 @@
 use std::{
     borrow::Cow,
     collections::HashMap,
-    path::{Path, PathBuf},
+    ffi::OsStr,
+    fs,
+    path::{Component, Path, PathBuf},
 };
 
 use dwall::{
-    ColorScheme, DWALL_CONFIG_DIR, DWALL_LOG_DIR, DisplayMonitor, config::Network,
-    domain::geography::check_location_permission, read_config_file as dwall_read_config,
-    write_config_file as dwall_write_config,
+    ColorScheme, DWALL_CONFIG_DIR, DWALL_LOG_DIR, DisplayMonitor,
+    config::{ImageFormat, Network},
+    domain::geography::check_location_permission,
+    read_config_file as dwall_read_config, write_config_file as dwall_write_config,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, ResourceId, Runtime, Url, Webview, WebviewWindow};
 use tauri_plugin_updater::UpdaterExt;
 
 use crate::{
     domain::{monitor::get_monitors, settings::Config, theme::validate_solar_theme},
-    error::{DwallSettingsError, DwallSettingsResult},
+    error::DwallSettingsResult,
     infrastructure::{
         filesystem::{find_files_in_dir, list_subdirectories, move_directory},
         network::download::ThemeDownloader,
@@ -97,8 +100,10 @@ pub async fn validate_theme_cmd(
     themes_directory: &Path,
     theme_id: &str,
     is_customized: bool,
+    image_format: ImageFormat,
 ) -> DwallSettingsResult<()> {
-    validate_solar_theme(themes_directory, theme_id, is_customized).map_err(Into::into)
+    validate_solar_theme(themes_directory, theme_id, is_customized, &image_format)
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -247,36 +252,71 @@ pub async fn check_for_updates_cmd<R: Runtime>(
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Theme {
+pub struct CustomizedTheme {
     id: String,
-    thumbnail: Vec<PathBuf>,
-    is_customized: bool,
+    directory: PathBuf,
+    thumbnails: Vec<PathBuf>,
+    #[serde(flatten)]
+    metadata: CustomizedThemeMetadata,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CustomizedThemeMetadata {
+    image_format: ImageFormat,
+    theme_name: String,
+    author: String,
+    version: u16,
 }
 
 #[tauri::command]
 pub async fn get_customized_themes_cmd(
     customized_themes_directory: PathBuf,
-) -> DwallSettingsResult<Vec<Theme>> {
+) -> DwallSettingsResult<Vec<CustomizedTheme>> {
     if !customized_themes_directory.exists() {
         return Ok(Vec::new());
     }
 
     let subdirs = list_subdirectories(&customized_themes_directory).await?;
-    debug!("Found {} subdirectories", subdirs.len());
+    debug!(subdirs = ?subdirs, "Found subdirectories");
 
     let mut themes = Vec::with_capacity(subdirs.len());
-    for subdir in subdirs {
-        let files = find_files_in_dir(&subdir.join("thumbnails"), "avif").await?;
-        let id = subdir
-            .file_name()
-            .and_then(|n| n.to_str())
-            .ok_or(DwallSettingsError::Other(
-                "Failed to get theme ID".to_string(),
-            ))?;
-        themes.push(Theme {
-            id: id.to_string(),
-            thumbnail: files,
-            is_customized: true,
+    for subdir in subdirs
+        .into_iter()
+        .filter(|p| p.components().next_back() != Some(Component::Normal(OsStr::new("backup"))))
+    {
+        let metadata_file = subdir.join("metadata.toml");
+        let metadata_content = fs::read_to_string(&metadata_file)
+            .inspect_err(|e| error!(error = ?e, "Failed to read metadata.toml"))?;
+        let metadata: CustomizedThemeMetadata = toml::from_str(&metadata_content)
+            .inspect_err(|e| error!(error = ?e, "Failed to parse metadata"))?;
+
+        let images = find_files_in_dir(&subdir.join("images"), metadata.image_format.as_str())
+            .await
+            .inspect_err(|e| error!(error = ?e, "Failed to find images in directory"))?;
+
+        let thumbnails = find_files_in_dir(&subdir.join("thumbnails"), "avif")
+            .await
+            .inspect_err(|e| error!(error = ?e, "Failed to find avif files in directory"))?;
+
+        if images.len() != thumbnails.len() {
+            error!(
+                images = images.len(),
+                thumbnails = thumbnails.len(),
+                "Invalid subject: number of images and thumbnails are not equal"
+            );
+            continue;
+        }
+
+        themes.push(CustomizedTheme {
+            id: format!(
+                "{}-{}-v{}",
+                metadata.theme_name.replace(" ", "-"),
+                metadata.author,
+                metadata.version
+            ),
+            directory: subdir,
+            thumbnails,
+            metadata,
         });
     }
 

--- a/crates/dwall-settings/src/domain/theme.rs
+++ b/crates/dwall-settings/src/domain/theme.rs
@@ -6,6 +6,7 @@ use std::io::Read;
 use std::path::Path;
 
 use dwall::ThemeValidator;
+use dwall::config::ImageFormat;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -19,8 +20,9 @@ pub fn validate_solar_theme(
     themes_directory: &Path,
     theme_id: &str,
     is_customized: bool,
+    image_format: &ImageFormat,
 ) -> Result<(), dwall::error::DwallError> {
-    ThemeValidator::validate(themes_directory, theme_id, is_customized)
+    ThemeValidator::validate(themes_directory, theme_id, is_customized, image_format)
 }
 
 /// Attempts to read the most recent error from the daemon log file

--- a/crates/dwall-settings/src/error.rs
+++ b/crates/dwall-settings/src/error.rs
@@ -33,6 +33,10 @@ pub enum DwallSettingsError {
     Logger(#[from] log::SetLoggerError),
     #[error(transparent)]
     DirectoryMove(#[from] DirectoryMoveError),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    TomlDeserialize(#[from] toml::de::Error),
     #[error("{0}")]
     Other(String),
 }

--- a/crates/dwall/src/config.rs
+++ b/crates/dwall/src/config.rs
@@ -23,15 +23,26 @@ const DEFAULT_TITLE_BAR_COLOR_FOLLOWS_WINDOWS_THEME: bool = false;
 pub enum ImageFormat {
     #[default]
     Jpeg,
+    Png,
 }
 
-impl From<&ImageFormat> for &str {
-    fn from(val: &ImageFormat) -> Self {
-        match val {
+impl ImageFormat {
+    pub fn as_str(&self) -> &'static str {
+        match self {
             ImageFormat::Jpeg => "jpg",
+            ImageFormat::Png => "png",
         }
     }
 }
+
+// impl From<&ImageFormat> for &str {
+//     fn from(val: &ImageFormat) -> Self {
+//         match val {
+//             ImageFormat::Jpeg => "jpg",
+//             ImageFormat::Png => "png",
+//         }
+//     }
+// }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(rename_all = "UPPERCASE", tag = "type")]

--- a/crates/dwall/src/domain/visual/theme_processor.rs
+++ b/crates/dwall/src/domain/visual/theme_processor.rs
@@ -258,6 +258,7 @@ impl ThemeValidator {
         themes_directory: &Path,
         theme_identifier: &str,
         is_customized: bool,
+        image_format: &ImageFormat,
     ) -> DwallResult<()> {
         trace!(
             theme_id = theme_identifier,
@@ -265,11 +266,7 @@ impl ThemeValidator {
             "Starting solar theme validation"
         );
 
-        let theme_directory_path = if is_customized {
-            themes_directory.join(theme_identifier).join("images")
-        } else {
-            themes_directory.join(theme_identifier)
-        };
+        let theme_directory_path = themes_directory.join(theme_identifier);
 
         if !theme_directory_path.exists() {
             warn!(
@@ -287,8 +284,12 @@ impl ThemeValidator {
             .map(|angle| angle.index())
             .collect();
 
-        if !Self::validate_theme_image_files(&theme_directory_path, &expected_image_indices, "jpg")
-        {
+        if !Self::validate_theme_image_files(
+            &theme_directory_path,
+            &expected_image_indices,
+            is_customized,
+            image_format.as_str(),
+        ) {
             warn!(
                 theme_id = theme_identifier,
                 expected_images = expected_image_indices.len(),
@@ -354,9 +355,14 @@ impl ThemeValidator {
     fn validate_theme_image_files(
         theme_directory: &Path,
         expected_image_indices: &[u8],
+        is_customized: bool,
         image_file_format: &str,
     ) -> bool {
-        let images_directory_path = theme_directory.join(image_file_format);
+        let images_directory_path = if is_customized {
+            theme_directory.join("images")
+        } else {
+            theme_directory.join(image_file_format)
+        };
 
         if !images_directory_path.is_dir() {
             warn!(
@@ -464,16 +470,20 @@ fn load_cached_solar_angles(theme_directory: &Path) -> DwallResult<Vec<SolarAngl
 }
 
 /// Build wallpaper file path based on theme directory, image format, and solar image index
-fn construct_wallpaper_file_path<'a>(
+fn construct_wallpaper_file_path(
     theme_directory_path: &Path,
-    image_file_format: impl Into<&'a str>,
+    image_format: &str,
     solar_image_index: u8,
+    is_customized: bool,
 ) -> PathBuf {
-    let image_format_str = image_file_format.into();
-    let mut wallpaper_path = theme_directory_path.to_path_buf();
-    wallpaper_path.push(image_format_str);
-    wallpaper_path.push(format!("{}.{}", solar_image_index + 1, image_format_str));
-    wallpaper_path
+    let image_file_name = format!("{}.{}", solar_image_index + 1, image_format);
+    if is_customized {
+        theme_directory_path.join("images").join(image_file_name)
+    } else {
+        theme_directory_path
+            .join(image_format)
+            .join(image_file_name)
+    }
 }
 
 /// Find the wallpaper image that best matches the current solar position
@@ -569,7 +579,9 @@ fn process_solar_theme_cycle(
             lock_screen_theme_identifier = Some(assigned_theme_id.to_string());
         }
 
-        let theme_directory_path = get_theme_directory_path(configuration, assigned_theme_id);
+        let (theme_directory_path, is_customized) =
+            get_theme_directory_path(configuration, assigned_theme_id);
+        info!(theme_directory = %theme_directory_path.display(), is_customized = is_customized, theme_id = assigned_theme_id, "Using theme directory");
 
         if let Err(processing_error) = update_monitor_solar_wallpaper(
             configuration.image_format(),
@@ -578,6 +590,7 @@ fn process_solar_theme_cycle(
             &theme_directory_path,
             &current_solar_position,
             wallpaper_manager,
+            is_customized,
         ) {
             error!(
                 error = %processing_error,
@@ -595,18 +608,22 @@ fn process_solar_theme_cycle(
     if configuration.lock_screen_wallpaper_enabled()
         && successful_monitor_count > 0
         && let Some(ref lock_screen_theme_id) = lock_screen_theme_identifier
-        && let Err(lock_screen_error) = apply_lock_screen_solar_wallpaper(
+    {
+        let (theme_directory_path, is_customized) =
+            get_theme_directory_path(configuration, lock_screen_theme_id);
+        if let Err(lock_screen_error) = apply_lock_screen_solar_wallpaper(
             configuration.image_format(),
             lock_screen_theme_id,
-            &get_theme_directory_path(configuration, lock_screen_theme_id),
+            &theme_directory_path,
             &current_solar_position,
-        )
-    {
-        warn!(
-            error = %lock_screen_error,
-            theme_id = lock_screen_theme_id,
-            "Failed to apply solar wallpaper to lock screen, continuing with other operations"
-        );
+            is_customized,
+        ) {
+            warn!(
+                error = %lock_screen_error,
+                theme_id = lock_screen_theme_id,
+                "Failed to apply solar wallpaper to lock screen, continuing with other operations"
+            );
+        }
     }
 
     let cache = get_cache();
@@ -673,17 +690,23 @@ fn update_monitor_solar_wallpaper(
     theme_directory_path: &Path,
     current_sun_position: &SolarPosition,
     wallpaper_manager: &WallpaperSetter,
+    is_customized: bool,
 ) -> DwallResult<()> {
     let (optimal_image_index, _) =
         find_optimal_solar_wallpaper(theme_directory_path, current_sun_position)?;
-    let wallpaper_file_path =
-        construct_wallpaper_file_path(theme_directory_path, image_format, optimal_image_index);
+    let wallpaper_file_path = construct_wallpaper_file_path(
+        theme_directory_path,
+        image_format.as_str(),
+        optimal_image_index,
+        is_customized,
+    );
 
     info!(
         wallpaper_path = %wallpaper_file_path.display(),
         image_index = optimal_image_index,
         monitor_id = monitor_identifier,
         theme_id = theme_identifier,
+        is_customized = is_customized,
         "Selected optimal solar wallpaper for monitor"
     );
 
@@ -716,13 +739,15 @@ fn apply_lock_screen_solar_wallpaper(
     theme_identifier: &str,
     theme_directory_path: &Path,
     current_sun_position: &SolarPosition,
+    is_customized: bool,
 ) -> DwallResult<()> {
     match find_optimal_solar_wallpaper(theme_directory_path, current_sun_position) {
         Ok((optimal_image_index, _)) => {
             let wallpaper_file_path = construct_wallpaper_file_path(
                 theme_directory_path,
-                image_format,
+                image_format.as_str(),
                 optimal_image_index,
+                is_customized,
             );
 
             if wallpaper_file_path.exists() {
@@ -774,13 +799,15 @@ pub async fn apply_solar_theme(configuration: Config) -> DwallResult<()> {
     solar_theme_processor.start_solar_update_loop()
 }
 
-fn get_theme_directory_path(configuration: &Config, theme_identifier: &str) -> PathBuf {
-    let mut path = configuration.themes_directory().join(theme_identifier);
-    if !path.exists() {
-        path = configuration
-            .customized_themes_directory()
-            .join(theme_identifier)
-            .join("images");
+fn get_theme_directory_path(configuration: &Config, theme_identifier: &str) -> (PathBuf, bool) {
+    let path = configuration.themes_directory().join(theme_identifier);
+    if path.exists() {
+        return (path, false);
     }
-    path
+
+    let path = configuration
+        .customized_themes_directory()
+        .join(theme_identifier);
+
+    (path, true)
 }

--- a/crates/dwall/src/lib.rs
+++ b/crates/dwall/src/lib.rs
@@ -28,4 +28,5 @@ pub use infrastructure::platform::windows::{RegistryError, RegistryKey};
 pub use domain::geography::CoordinateError;
 pub use domain::geography::GeolocationAccessError;
 pub use domain::geography::Position as GeographicPosition;
+pub use domain::time::solar_calculator::SolarAngle;
 pub use domain::visual::ColorScheme;

--- a/src/commands/theme.ts
+++ b/src/commands/theme.ts
@@ -1,15 +1,18 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { ThemeID, ThemeItem } from "~/themes";
+import type { ThemeID } from "~/themes";
+import type { CustomizedTheme } from "~/types";
 
 export const validateTheme = async (
   themesDirectory: string,
   themeId: string,
+  imageFormat: CustomizedTheme["image_format"],
   isCustomized = false,
 ) =>
   invoke<void>("validate_theme_cmd", {
     themesDirectory,
     themeId,
     isCustomized,
+    imageFormat,
   });
 
 export const applyTheme = async (config: Config) =>
@@ -41,6 +44,6 @@ export const clearThumbnailCache = async () =>
   invoke<number>("clear_thumbnail_cache_cmd");
 
 export const getCustomizedThemes = async (customizedThemesDirectory: string) =>
-  invoke<ThemeItem[]>("get_customized_themes_cmd", {
+  invoke<CustomizedTheme[]>("get_customized_themes_cmd", {
     customizedThemesDirectory,
   });

--- a/src/contexts/ThemesContext.tsx
+++ b/src/contexts/ThemesContext.tsx
@@ -1,18 +1,19 @@
 import { createContext, useContext, type ParentProps } from "solid-js";
 import { useThemes } from "~/hooks/theme/useThemes";
 import type { ThemeItem } from "~/themes";
+import type { CustomizedTheme } from "~/types";
 
 interface ThemesContext {
-  themes: Accessor<ThemeItem[]>;
+  allThemes: Accessor<(CustomizedTheme | ThemeItem)[]>;
 }
 
 const ThemesContext = createContext<ThemesContext>();
 
 export const ThemesProvider = (props: ParentProps) => {
-  const { themes } = useThemes();
+  const { allThemes } = useThemes();
 
   return (
-    <ThemesContext.Provider value={{ themes }}>
+    <ThemesContext.Provider value={{ allThemes }}>
       {props.children}
     </ThemesContext.Provider>
   );

--- a/src/hooks/theme/useThemes.tsx
+++ b/src/hooks/theme/useThemes.tsx
@@ -9,13 +9,13 @@ export const useThemes = () => {
     () => config()?.customized_themes_directory,
     getCustomizedThemes,
   );
-  const mergedThemes = createMemo(() => {
-    return [...(customizedThemes() ?? []), ...themes].sort((a, b) =>
-      a.id.localeCompare(b.id),
-    );
-  });
+
+  const allThemes = createMemo(() => [
+    ...(customizedThemes() ?? []),
+    ...themes,
+  ]);
 
   return {
-    themes: mergedThemes,
+    allThemes,
   };
 };

--- a/src/layout/sidebar/AppSidebar.tsx
+++ b/src/layout/sidebar/AppSidebar.tsx
@@ -26,6 +26,7 @@ import type { ThemeItem } from "~/themes";
 import { route, navigate } from "~/router";
 import { t } from "~/i18n";
 import { clsx } from "~/utils";
+import type { CustomizedTheme } from "~/types";
 
 const [imageHeights, setImageHeights] = createStore<Record<string, number>>({});
 
@@ -40,7 +41,7 @@ export const AppSidebar = () => {
     return r.id;
   });
 
-  const { themes } = useThemesContext();
+  const { allThemes } = useThemesContext();
 
   return (
     <Sidebar
@@ -54,7 +55,7 @@ export const AppSidebar = () => {
             !theme.downloadingTheme() ? "scrollbar" : "overflow-y-hidden",
           )}
         >
-          <For each={themes()}>
+          <For each={allThemes()}>
             {(item, index) => (
               <Show when={config.state === "ready"} fallback={<Spinner />}>
                 <ThemeMenuItem
@@ -116,7 +117,7 @@ export const AppSidebar = () => {
 };
 
 const ThemeMenuItem = (
-  props: ThemeItem & {
+  props: (ThemeItem | CustomizedTheme) & {
     github_mirror_template?: string;
     disabled?: boolean;
     active: boolean;
@@ -137,10 +138,10 @@ const ThemeMenuItem = (
             <ThemeImage
               class="rounded-sm"
               src={generateGitHubThumbnailMirrorUrl(
-                props.thumbnail[0],
+                props.thumbnails[0],
                 props.github_mirror_template,
               )}
-              isLocal={props.isCustomized}
+              isLocal={"author" in props}
               width={64}
               themeID={props.id}
               serialNumber={props.index + 1}
@@ -158,7 +159,9 @@ const ThemeMenuItem = (
             </Show>
           </SidebarMenuButton>
         </TooltipTrigger>
-        <TooltipContent side="right">{props.id}</TooltipContent>
+        <TooltipContent side="right">
+          {"theme_name" in props ? props.theme_name : props.id}
+        </TooltipContent>
       </Tooltip>
     </SidebarMenuItem>
   );

--- a/src/layout/theme/Actions.tsx
+++ b/src/layout/theme/Actions.tsx
@@ -5,11 +5,13 @@ import { Button } from "~/components/button";
 import { validateTheme } from "~/commands";
 import Download from "./Download";
 import { t } from "~/i18n";
+import type { ImageFormat } from "~/types";
 
 interface ThemeActionsProps {
   currentThemeID: string;
   themesDirectory?: string;
   isCustomized?: boolean;
+  imageFormat: ImageFormat;
 }
 
 const ThemeActions = (props: ThemeActionsProps) => {
@@ -45,6 +47,7 @@ const ThemeActions = (props: ThemeActionsProps) => {
       await validateTheme(
         props.themesDirectory,
         props.currentThemeID,
+        props.imageFormat,
         props.isCustomized,
       );
       setThemeExists(true);

--- a/src/layout/theme/Theme.tsx
+++ b/src/layout/theme/Theme.tsx
@@ -27,7 +27,7 @@ interface ThemeProps {
 
 export const Theme = (props: ThemeProps) => {
   const { data: config } = useConfig();
-  const { themes } = useThemesContext();
+  const { allThemes } = useThemesContext();
   const {
     list: monitors,
     handleChange: handleMonitorChange,
@@ -47,11 +47,26 @@ export const Theme = (props: ThemeProps) => {
   };
 
   const theme = createMemo(() => {
-    return config() && themes().find((t) => t.id === props.id);
+    return config() && allThemes().find((t) => t.id === props.id);
+  });
+
+  const isCustomized = createMemo(() => {
+    const t = theme();
+    return t && "author" in t;
+  });
+
+  const themeName = createMemo(() => {
+    const t = theme();
+    return t && "theme_name" in t ? t.theme_name : props.id;
+  });
+
+  const imageFormat = createMemo(() => {
+    const t = theme();
+    return t && "image_format" in t ? t.image_format : "jpeg";
   });
 
   createEffect(() => {
-    setStore({ count: theme()?.thumbnail.length, current: 0 });
+    setStore({ count: theme()?.thumbnails.length, current: 0 });
   });
 
   return (
@@ -76,7 +91,7 @@ export const Theme = (props: ThemeProps) => {
           id={props.id}
         >
           <CarouselContent>
-            <For each={theme()?.thumbnail}>
+            <For each={theme()?.thumbnails}>
               {(src, index) => (
                 <CarouselItem class="min-w-108">
                   <AspectRatio
@@ -94,7 +109,7 @@ export const Theme = (props: ThemeProps) => {
                             )
                           : src
                       }
-                      isLocal={theme()?.isCustomized}
+                      isLocal={isCustomized()}
                       class="rounded-md"
                       themeID={props.id}
                       serialNumber={index() + 1}
@@ -123,7 +138,7 @@ export const Theme = (props: ThemeProps) => {
           class="absolute top-(--name-top) right-2 bg-neutral-950/30 rounded-2xl text-white dark:text-white/60 py-0.5 px-2 text-xs font-medium backdrop-blur-sm"
           style={{ "--name-top": `${nameTop()}px` }}
         >
-          {props.id}
+          {themeName()}
         </p>
 
         <div
@@ -131,7 +146,7 @@ export const Theme = (props: ThemeProps) => {
           style={{ "--indicators-bottom": `${indicatorsBottom()}px` }}
         >
           <div class="flex gap-1.5 z-10 py-1 px-1.5 bg-neutral-950/30 rounded-2xl backdrop-blur-sm">
-            <For each={theme()?.thumbnail}>
+            <For each={theme()?.thumbnails}>
               {(_, index) => (
                 <button
                   type="button"
@@ -152,11 +167,12 @@ export const Theme = (props: ThemeProps) => {
         <ThemeActions
           currentThemeID={props.id}
           themesDirectory={
-            theme()?.isCustomized
+            isCustomized()
               ? config()?.customized_themes_directory
               : config()?.themes_directory
           }
-          isCustomized={theme()?.isCustomized}
+          isCustomized={isCustomized()}
+          imageFormat={imageFormat()}
         />
       </div>
     </div>

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,7 +2,7 @@ import { createSignal } from "solid-js";
 import type { ThemeID } from "~/themes";
 
 export type SettingsRoute = { path: "settings" };
-export type ThemeRoute = { path: "theme"; id: ThemeID };
+export type ThemeRoute = { path: "theme"; id: string };
 export type Route = SettingsRoute | ThemeRoute;
 
 const [route, setRoute] = createSignal<Route>({

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -23,7 +23,7 @@ export type ThemeID = keyof typeof thumbnails_count;
 
 export interface ThemeItem {
   id: ThemeID;
-  thumbnail: string[];
+  thumbnails: string[];
   isCustomized?: boolean;
 }
 
@@ -32,7 +32,7 @@ export const themes: ThemeItem[] = (
 )
   .map(([id, count]) => ({
     id,
-    thumbnail: Array.from(
+    thumbnails: Array.from(
       { length: count },
       (_, i) => `${thumbnails_base_url}${id.replaceAll(" ", "")}/${i + 1}.avif`,
     ),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from "./props.types";
+export * from "./theme.types";
 
 export type MakeRequired<T, K extends keyof T> = Omit<T, K> &
   Required<Pick<T, K>>;

--- a/src/types/theme.types.ts
+++ b/src/types/theme.types.ts
@@ -1,0 +1,11 @@
+export type ImageFormat = "jpeg" | "png";
+
+export interface CustomizedTheme {
+  id: string;
+  directory: string;
+  image_format: ImageFormat;
+  theme_name: string;
+  author: string;
+  thumbnails: string[];
+  version: number;
+}


### PR DESCRIPTION
Add support for PNG image format alongside existing JPEG support in customized themes. The theme validation now checks for images in a dedicated `images` directory rather than format-specific subdirectories for customized themes. Introduce `CustomizedTheme` metadata parsing from `metadata.toml` files, including fields for image format, theme name, author, and version. Refactor the theme validation logic to handle both customized and non-customized themes with appropriate directory structures. Add `Png` variant to `ImageFormat` enum and provide `as_str()` method for file extension lookup. Update frontend types and components to work with the new `CustomizedTheme` structure.